### PR TITLE
ISSUE-86 Replaced 2016 with 2017 only in 2 html footers and license agreement

### DIFF
--- a/rnacentral/apiv1/rest_framework_override/throttling.py
+++ b/rnacentral/apiv1/rest_framework_override/throttling.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/serializers.py
+++ b/rnacentral/apiv1/serializers.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/templates/rest_framework/api.html
+++ b/rnacentral/apiv1/templates/rest_framework/api.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/templates/rest_framework/base.html
+++ b/rnacentral/apiv1/templates/rest_framework/base.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/tests.py
+++ b/rnacentral/apiv1/tests.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/urls.py
+++ b/rnacentral/apiv1/urls.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/export/settings.py
+++ b/rnacentral/export/settings.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/export/tests.py
+++ b/rnacentral/export/tests.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/export/urls.py
+++ b/rnacentral/export/urls.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/export/views.py
+++ b/rnacentral/export/views.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/fabfile.py
+++ b/rnacentral/fabfile.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/manage.py
+++ b/rnacentral/manage.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/management/commands/nhmmer_worker.py
+++ b/rnacentral/nhmmer/management/commands/nhmmer_worker.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/messages.py
+++ b/rnacentral/nhmmer/messages.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/models.py
+++ b/rnacentral/nhmmer/models.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/nhmmer_parse.py
+++ b/rnacentral/nhmmer/nhmmer_parse.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/nhmmer_search.py
+++ b/rnacentral/nhmmer/nhmmer_search.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/settings.py
+++ b/rnacentral/nhmmer/settings.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/templates/nhmmer/dashboard.html
+++ b/rnacentral/nhmmer/templates/nhmmer/dashboard.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/templates/nhmmer/sequence-search.html
+++ b/rnacentral/nhmmer/templates/nhmmer/sequence-search.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/tests.py
+++ b/rnacentral/nhmmer/tests.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/urls.py
+++ b/rnacentral/nhmmer/urls.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/utils.py
+++ b/rnacentral/nhmmer/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/nhmmer/views.py
+++ b/rnacentral/nhmmer/views.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/admin.py
+++ b/rnacentral/portal/admin.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/config/expert_databases.py
+++ b/rnacentral/portal/config/expert_databases.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/config/genomes.py
+++ b/rnacentral/portal/config/genomes.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/context_processors.py
+++ b/rnacentral/portal/context_processors.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/forms.py
+++ b/rnacentral/portal/forms.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/common_exporters/oracle_connection.py
+++ b/rnacentral/portal/management/commands/common_exporters/oracle_connection.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/database_stats.py
+++ b/rnacentral/portal/management/commands/database_stats.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_export.py
+++ b/rnacentral/portal/management/commands/ftp_export.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/bed.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/bed.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/fasta.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/fasta.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/ftp_base.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/ftp_base.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/gff.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/gff.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/md5.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/md5.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/trackhub.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/trackhub.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/ftp_exporters/xrefs.py
+++ b/rnacentral/portal/management/commands/ftp_exporters/xrefs.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/gpi_export.py
+++ b/rnacentral/portal/management/commands/gpi_export.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/import_pdb_modifications.py
+++ b/rnacentral/portal/management/commands/import_pdb_modifications.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/precompute_descriptions.py
+++ b/rnacentral/portal/management/commands/precompute_descriptions.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/xml_export.py
+++ b/rnacentral/portal/management/commands/xml_export.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/xml_export_parallel.py
+++ b/rnacentral/portal/management/commands/xml_export_parallel.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
+++ b/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/css/main.css
+++ b/rnacentral/portal/static/css/main.css
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.ExpertDatabaseSequenceDistribution.js
+++ b/rnacentral/portal/static/js/d3/d3.ExpertDatabaseSequenceDistribution.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.ExpertDatabaseTreemap.js
+++ b/rnacentral/portal/static/js/d3/d3.ExpertDatabaseTreemap.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.nhmmerDashboard.js
+++ b/rnacentral/portal/static/js/d3/d3.nhmmerDashboard.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.sequencesOverTime.js
+++ b/rnacentral/portal/static/js/d3/d3.sequencesOverTime.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.speciesSunburst.js
+++ b/rnacentral/portal/static/js/d3/d3.speciesSunburst.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/d3/d3.speciesTree.js
+++ b/rnacentral/portal/static/js/d3/d3.speciesTree.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/genoverse.RNAcentralTrack.js
+++ b/rnacentral/portal/static/js/genoverse.RNAcentralTrack.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/guidedTour.js
+++ b/rnacentral/portal/static/js/guidedTour.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/jquery.EuropePMCAbstracts.js
+++ b/rnacentral/portal/static/js/jquery.EuropePMCAbstracts.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/rnaView.js
+++ b/rnacentral/portal/static/js/rnaView.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/search/export-results.search.js
+++ b/rnacentral/portal/static/js/search/export-results.search.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/search/metadata.search.js
+++ b/rnacentral/portal/static/js/search/metadata.search.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/static/js/search/nhmmer.sequence.search.js
+++ b/rnacentral/portal/static/js/search/nhmmer.sequence.search.js
@@ -1,5 +1,5 @@
 /*
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/about.html
+++ b/rnacentral/portal/templates/portal/about.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/base.html
+++ b/rnacentral/portal/templates/portal/base.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/coming-soon.html
+++ b/rnacentral/portal/templates/portal/coming-soon.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/contact.html
+++ b/rnacentral/portal/templates/portal/contact.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/docs/training.md
+++ b/rnacentral/portal/templates/portal/docs/training.md
@@ -23,7 +23,7 @@ RNAcentral has been described in several papers:
 
 <blockquote class="callout-info">
   <p>RNAcentral: a comprehensive database of non-coding RNA sequences</p>
-  <footer>The RNAcentral Consortium, 2016</footer>
+  <footer>The RNAcentral Consortium, 2017</footer>
   <footer><em>Nucleic Acids Research (Database issue)</em></footer>
   <a href="http://nar.oxfordjournals.org/content/early/2016/10/28/nar.gkw1008.long">NAR</a> |
   <a href="http://europepmc.org/abstract/MED/27794554">EuropePMC</a> |

--- a/rnacentral/portal/templates/portal/downloads.html
+++ b/rnacentral/portal/templates/portal/downloads.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/error.html
+++ b/rnacentral/portal/templates/portal/error.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/expert-database.html
+++ b/rnacentral/portal/templates/portal/expert-database.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/expert-databases-d3.html
+++ b/rnacentral/portal/templates/portal/expert-databases-d3.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/expert-databases.html
+++ b/rnacentral/portal/templates/portal/expert-databases.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/footer.html
+++ b/rnacentral/portal/templates/portal/footer.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/genome-browser.html
+++ b/rnacentral/portal/templates/portal/genome-browser.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/header.html
+++ b/rnacentral/portal/templates/portal/header.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/help/api-v1.html
+++ b/rnacentral/portal/templates/portal/help/api-v1.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/help/browser-compatibility.html
+++ b/rnacentral/portal/templates/portal/help/browser-compatibility.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/help/faq.html
+++ b/rnacentral/portal/templates/portal/help/faq.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/help/genomic-mapping.html
+++ b/rnacentral/portal/templates/portal/help/genomic-mapping.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/help/metadata-search.html
+++ b/rnacentral/portal/templates/portal/help/metadata-search.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/homepage.html
+++ b/rnacentral/portal/templates/portal/homepage.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -185,7 +185,7 @@ RNAcentral
               please cite the following paper:
               <blockquote class="callout-info">
                 <p>RNAcentral: a comprehensive database of non-coding RNA sequences</p>
-                <footer>The RNAcentral Consortium, 2016</footer>
+                <footer>The RNAcentral Consortium, 2017</footer>
                 <footer><em>Nucleic Acids Research (Database Issue)</em></footer>
               </blockquote>
             </p>

--- a/rnacentral/portal/templates/portal/search/export-job-results.html
+++ b/rnacentral/portal/templates/portal/search/export-job-results.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/search/metadata-search-results.html
+++ b/rnacentral/portal/templates/portal/search/metadata-search-results.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/thanks.html
+++ b/rnacentral/portal/templates/portal/thanks.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/training.html
+++ b/rnacentral/portal/templates/portal/training.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/unique-rna-sequence.html
+++ b/rnacentral/portal/templates/portal/unique-rna-sequence.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/website-status.html
+++ b/rnacentral/portal/templates/portal/website-status.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templates/portal/xref-table.html
+++ b/rnacentral/portal/templates/portal/xref-table.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/templatetags/portal_extras.py
+++ b/rnacentral/portal/templatetags/portal_extras.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/tests/selenium_tests.py
+++ b/rnacentral/portal/tests/selenium_tests.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/urls.py
+++ b/rnacentral/portal/urls.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/portal/views.py
+++ b/rnacentral/portal/views.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/rnacentral/local_settings_default.py
+++ b/rnacentral/rnacentral/local_settings_default.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/rnacentral/settings.py
+++ b/rnacentral/rnacentral/settings.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/rnacentral/urls.py
+++ b/rnacentral/rnacentral/urls.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/rnacentral/utils.py
+++ b/rnacentral/rnacentral/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/rnacentral/wsgi.py
+++ b/rnacentral/rnacentral/wsgi.py
@@ -1,5 +1,5 @@
 """
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/templates/404.html
+++ b/rnacentral/templates/404.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/templates/500.html
+++ b/rnacentral/templates/500.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/templates/503.html
+++ b/rnacentral/templates/503.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rnacentral/templates/admin/base_site.html
+++ b/rnacentral/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 <!--
-Copyright [2009-2016] EMBL-European Bioinformatics Institute
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
All the remaining occurences of string "2016" in the project are meaningful and shouldn't be replaced.