### PR TITLE
Add penalty for generic types of RNA

### DIFF
--- a/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
+++ b/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
@@ -279,6 +279,12 @@ class RnaXmlExporter(OracleConnection):
         else:
             # basic priority level
             boost = 1
+
+        generic_types = set(['misc_RNA', 'misc RNA', 'other'])
+        if len(self.data['rna_type']) == 1 and \
+                generic_types.intersection(self.data['rna_type']):
+            boost = boost - 0.5
+
         self.data['boost'] = boost
 
     def store_rna_properties(self, rna, taxid):


### PR DESCRIPTION
When doing a search by organism sometimes the first hits are all generic
misc RNA's. We don't want these at the top of search, despite being the
longest because other more specific RNA's are more interesting. Thus I
add a small (0.5) penalty to such RNA's. This small penalty will force
the generic results downward, while not placing them below things of a
similar priority. For example, human RNA will always be listed before
other species, but the miscRNA will not appear first.