### PR TITLE
Correct bed export

### DIFF
--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -284,7 +284,7 @@ class Rna(CachingMixin, models.Model):
         Example:
         chr1    29554    31097    RNA000063C361    0    +   29554    31097    255,0,0    3    486,104,122    0,1009,1421
         """
-        xrefs = self.xrefs.filter(db__project_id__isnull=True).all()
+        xrefs = self.xrefs.filter(deleted='N').all()
         bed = ''
         for xref in xrefs:
             bed += _xref_to_bed_format(xref)

--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -971,7 +971,7 @@ class Xref(models.Model):
         """
         Format genomic coordinates in BED format.
         """
-        return _xref_to_bed_format(self)
+        return _xref_to_bed_format(self, taxid=self.taxid)
 
     def get_gff(self):
         """
@@ -1394,7 +1394,7 @@ class GffFormatter(Gff3Formatter):
         return ';'.join('%s "%s"' % (key, attributes[key]) for key in order)
 
 
-def _xref_to_bed_format(xref):
+def _xref_to_bed_format(xref, taxid=None):
     """
     Return genome coordinates of an xref in BED format. Available in Rna and Xref models.
     """
@@ -1413,6 +1413,8 @@ def _xref_to_bed_format(xref):
     chrom_start = xref.get_feature_start() - 1
     chrom_end = xref.get_feature_end()
     upi = xref.upi.upi
+    if taxid is not None:
+        upi += '_%s' % str(taxid)
     score = 0
     strand = '+' if xref.get_feature_strand() > 0 else '-'
     thick_start = chrom_start

--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -1410,7 +1410,7 @@ def _xref_to_bed_format(xref):
         return bed
     # prepare fields
     chromosome = xref.get_feature_chromosome()
-    chrom_start = xref.get_feature_start()
+    chrom_start = xref.get_feature_start() - 1
     chrom_end = xref.get_feature_end()
     upi = xref.upi.upi
     score = 0


### PR DESCRIPTION
This should clean up the bed file export to be more consistent with what is expected of BED files. That is 0 based coordinates and the same entries as found in GFF files. However, I've only noted these discrepancies in pombe, so it may be worthwhile for me to spend some time browsing other organisms to see if these problems occur in other places (I suspect they do).