### PR TITLE
115 xref filtering

### DIFF
--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -204,11 +204,14 @@ class Rna(CachingMixin, models.Model):
         else:
             return self.xrefs.filter(deleted='Y').select_related()
 
-    def count_xrefs(self):
+    def count_xrefs(self, taxid=None):
         """
         Count the number of cross-references associated with the sequence.
         """
-        return self.xrefs.filter(db__project_id__isnull=True, deleted='N').count()
+        xrefs = self.xrefs.filter(db__project_id__isnull=True, deleted='N')
+        if taxid:
+            xrefs = xrefs.filter(taxid=taxid)
+        return xrefs.count()        
 
     @cached_property
     def count_distinct_organisms(self):

--- a/rnacentral/portal/templates/portal/unique-rna-sequence.html
+++ b/rnacentral/portal/templates/portal/unique-rna-sequence.html
@@ -134,7 +134,7 @@ limitations under the License.
           <div>
             <h2>
               Annotations
-              <small id="xrefs-datatables-counter">{{ rna.count_xrefs|intcomma }} total</small>
+              <small id="xrefs-datatables-counter">{{ context.xrefs_count|intcomma }} total</small>
 
               <div class="btn-group btn-group-xs margin-left-5px btn-group-xref-sort" style="display:none">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
@@ -149,9 +149,9 @@ limitations under the License.
               <span id="xrefs-datatables-filter"></span>
             </h2>
 
-            {% if rna.count_xrefs > context.xref_page_size %}
+            {% if context.xrefs_count > context.xref_page_size %}
               <div class="alert alert-warning" role="alert">
-                Showing {{ context.xref_page_size|intcomma }} entries out of {{ rna.count_xrefs|intcomma }}.
+                Showing {{ context.xref_page_size|intcomma }} entries out of {{ context.xrefs_count|intcomma }}.
                 Navigate between batches:
                 <ul class="pagination pagination-sm">
                   {% for xref_page in context.xref_pages %}

--- a/rnacentral/portal/templates/portal/unique-rna-sequence.html
+++ b/rnacentral/portal/templates/portal/unique-rna-sequence.html
@@ -53,16 +53,7 @@ limitations under the License.
   <div class="alert alert-danger">
     No annotations from taxid:{{context.taxid_not_found}}.
   </div>
-{% elif context.taxid_filtering %}
-  <div class="well well-sm">
-    <i class="fa fa-filter"></i> Showing annotations from <strong><em>{{ context.single_species}}</em></strong>.
-
-    {% if rna.count_distinct_organisms > 1 %}
-      <a href="" class="show-species-tab">Switch species</a> or
-      <a href="{% url 'portal.views.rna_view' rna.upi %}">view all data</a> from {{ rna.count_distinct_organisms }} species.
-    {% endif %}
-  </div>
-{% elif rna.count_distinct_organisms > 1 %}
+{% elif not context.taxid_filtering and rna.count_distinct_organisms > 1 %}
   <div class="well well-sm">
     <i class="fa fa-info-circle"></i> This unique sequence was observed in multiple species.
     <a href="" class="show-species-tab">Filter annotations</a> by species.

--- a/rnacentral/portal/tests/selenium_tests.py
+++ b/rnacentral/portal/tests/selenium_tests.py
@@ -836,7 +836,6 @@ class RNAcentralTest(unittest.TestCase):
         self.assertEqual(len(species), 1)
         self.assertEqual(species.pop(), taxid['species'])
         self.assertEqual(page.get_page_subtitle(), taxid['species'])
-        self.assertIn('Showing annotations from ' + taxid['species'], page.get_info_text())
 
     def test_taxid_filtering_spurious_taxid(self):
         """

--- a/rnacentral/portal/views.py
+++ b/rnacentral/portal/views.py
@@ -210,6 +210,7 @@ def rna_view(request, upi, taxid=None):
         'xref_pages': get_xrefs_pages(),
         'xref_page_size': XREF_PAGE_SIZE,
         'xref_page_num': get_xref_page_num(),
+        'xrefs_count': rna.count_xrefs(taxid) if taxid_filtering else rna.count_xrefs(),
         'precomputed': RnaPrecomputed.objects.filter(upi=upi, taxid=taxid).first(),
     }
 


### PR DESCRIPTION
Google crawler complained about some slow loading pages, and many of them had the UI issue described in #115. 

I am hoping that page speed will improve after migrating to Postgres but the UI problem can be fixed now.

Examples:
* http://localhost:8000/rna/URS000042DDAB/1566162
* http://localhost:8000/rna/URS000042DDAB/

Fixes #115 