### PR TITLE
Add logic to append gene name for HGNC #167

### DIFF
--- a/rnacentral/portal/management/commands/import_hgnc.py
+++ b/rnacentral/portal/management/commands/import_hgnc.py
@@ -135,9 +135,14 @@ class HGNCImporter():
                 version=1,
                 taxid=9606
             )
+
+            gene_description = ''
+            if entry['symbol']:
+                gene_description = ' (%s)' % entry['symbol']
+
             Accession.objects.update_or_create(
                 accession=entry['hgnc_id'],
-                description='Homo sapiens ' + entry['name'],
+                description='Homo sapiens ' + entry['name'] + gene_description,
                 division='HUM',
                 species='Homo sapiens',
                 is_composite='N',

--- a/rnacentral/portal/tests/description_tests.py
+++ b/rnacentral/portal/tests/description_tests.py
@@ -66,19 +66,19 @@ class SimpleDescriptionTests(GenericDescriptionTest):
 class HumanDescriptionTests(GenericDescriptionTest):
     def test_likes_hgnc_for_human(self):
         self.assertDescriptionIs(
-            'DiGeorge syndrome critical region gene 9 (non-protein coding)',
+            'DiGeorge syndrome critical region gene 9 (non-protein coding) (DGCR9)',
             'URS0000759BEC',
             taxid=9606)
 
         self.assertDescriptionIs(
-            'STARD4 antisense RNA 1',
+            'STARD4 antisense RNA 1 (STARD4-AS1)',
             'URS00003CE153',
             taxid=9606)
 
         # NOTE: This is a bit questionable, there are other names which may
         # possibly be better
         self.assertDescriptionIs(
-            'small Cajal body-specific RNA 10',
+            'small Cajal body-specific RNA 10 (SCARNA10)',
             'URS0000569A4A',
             taxid=9606)
 
@@ -92,6 +92,13 @@ class HumanDescriptionTests(GenericDescriptionTest):
             'Homo sapiens (human) microRNA hsa-mir-1302-9 precursor',
             'URS000075CC93',
             taxid=9606)
+
+    def test_includes_gene_name_for_hgnc(self):
+        self.assertDescriptionIs(
+            'HOX transcript antisense RNA (HOTAIR)',
+            'URS000075C808',
+            taxid=9606
+        )
 
 
 class ArabidopisDescriptionTests(GenericDescriptionTest):

--- a/rnacentral/portal/utils/descriptions/rule_method.py
+++ b/rnacentral/portal/utils/descriptions/rule_method.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 """
 Copyright [2009-2017] EMBL-European Bioinformatics Institute
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from __future__ import unicode_literals
+
+import re
 import math
 import string
 import logging
@@ -263,7 +264,10 @@ def get_species_specific_name(rna_type, sequence, xrefs):
                 xref.accession.description)
 
     xref = max(best, key=description_order)
-    return xref.accession.description
+    description = xref.accession.description.strip()
+    if xref.accession.database == 'HGNC' and xref.accession.gene:
+        description = '%s (%s)' % (description, xref.accession.gene)
+    return description
 
 
 def correct_by_length(rna_type, sequence):

--- a/rnacentral/portal/utils/descriptions/rule_method.py
+++ b/rnacentral/portal/utils/descriptions/rule_method.py
@@ -264,10 +264,7 @@ def get_species_specific_name(rna_type, sequence, xrefs):
                 xref.accession.description)
 
     xref = max(best, key=description_order)
-    description = xref.accession.description.strip()
-    if xref.accession.database == 'HGNC' and xref.accession.gene:
-        description = '%s (%s)' % (description, xref.accession.gene)
-    return description
+    return xref.accession.description.strip()
 
 
 def correct_by_length(rna_type, sequence):


### PR DESCRIPTION
The gene name is informative and often useful for searching. By putting it in the name it is easier to search and find interesting sequences.