### PR TITLE
Correct exported rna type

### DIFF
--- a/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
+++ b/rnacentral/portal/management/commands/xml_exporters/rna2xml.py
@@ -176,16 +176,15 @@ class RnaXmlExporter(OracleConnection):
             """
             Use either feature name or ncRNA class (when feature is 'ncRNA')
             """
-            rna_types = []
-            precomputed = result['rna_type']
-            if precomputed:
-                rna_types.append(precomputed)
-            if not precomputed or 'antisense' in precomputed:
+            rna_type = None
+            if result['rna_type']:
+                rna_type = result['rna_type']
+            else:
                 if result['ncrna_class']:
-                    rna_types.append(result['ncrna_class'])
+                    rna_type = result['ncrna_class']
                 else:
-                    rna_types.append(result['feature_name'])
-            return [r.replace('_', ' ') for r in rna_types]
+                    rna_type = result['feature_name']
+            return [rna_type.replace('_', ' ')]
 
         def store_rna_type():
             """


### PR DESCRIPTION
This corrects part 2 in #161. The issue was that before if the RNA type was 'antisense_RNA' then we would find another RNA type and index that too. This is not what we want to happen so now we don't do that. If we don't have a precomputed RNA type it then uses feature_type or ncrna_type as needed. 

The changes have 2 parts. First I rework the xml_export command to accept an optional list of upis (with the --upis option) or the standard --min/--max. I used this to debug and fix the issues. In doing so I flattened out the structure of code. I had a lot of trouble following all the nested functions.