### PR TITLE
Remove (non-protein coding) for description text

### DIFF
--- a/rnacentral/portal/tests/description_tests.py
+++ b/rnacentral/portal/tests/description_tests.py
@@ -66,7 +66,7 @@ class SimpleDescriptionTests(GenericDescriptionTest):
 class HumanDescriptionTests(GenericDescriptionTest):
     def test_likes_hgnc_for_human(self):
         self.assertDescriptionIs(
-            'DiGeorge syndrome critical region gene 9 (non-protein coding) (DGCR9)',
+            'DiGeorge syndrome critical region gene 9 (DGCR9)',
             'URS0000759BEC',
             taxid=9606)
 

--- a/rnacentral/portal/utils/descriptions/rule_method.py
+++ b/rnacentral/portal/utils/descriptions/rule_method.py
@@ -264,9 +264,13 @@ def get_species_specific_name(rna_type, sequence, xrefs):
                 xref.accession.description)
 
     xref = max(best, key=description_order)
-    description = xref.accession.description.strip()
+    description = xref.accession.description
+    description = re.sub(r'\(\s*non-protein\s+coding\s*\)', '', description)
+    description = description.strip()
+
     if xref.accession.database == 'HGNC' and xref.accession.gene:
         description = '%s (%s)' % (description, xref.accession.gene)
+
     return description
 
 


### PR DESCRIPTION
This branch is based off the add-hgnc-gene-name-to-description branch as it is complementary to that work. We only store non-protein coding RNA so there is little reason to include the `(non-protein coding)` text in our descriptions. This adds a test and an example of stripping that text. I think this makes descriptions look nicer but is possibly unneeded. 

On the downside this could cause problems for external resources using our names in a context where protein coding genes are around. But I'm not sure how much we should worry about that. 