### PR TITLE
Add table to store secondary structures

### DIFF
--- a/rnacentral/portal/migrations/0012_auto_20170818_1016.py
+++ b/rnacentral/portal/migrations/0012_auto_20170818_1016.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SecondaryStructure',
             fields=[
-                ('ss_id', models.AutoField(serialize=False, primary_key=True)),
+                ('id', models.AutoField(serialize=False, primary_key=True)),
                 ('secondary_structure', models.TextField()),
                 ('md5', models.CharField(max_length=32, db_index=True)),
             ],

--- a/rnacentral/portal/migrations/0012_auto_20170818_1016.py
+++ b/rnacentral/portal/migrations/0012_auto_20170818_1016.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0011_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SecondaryStructure',
+            fields=[
+                ('ss_id', models.AutoField(serialize=False, primary_key=True)),
+                ('secondary_structure', models.TextField()),
+                ('md5', models.CharField(max_length=32, db_index=True)),
+            ],
+            options={
+                'db_table': 'rnc_secondary_structure',
+            },
+        ),
+        migrations.AddField(
+            model_name='secondarystructure',
+            name='accession',
+            field=models.ForeignKey(related_name='secondary_structure', db_column=b'rnc_accession_id', to='portal.Accession'),
+        ),
+    ]

--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -211,7 +211,7 @@ class Rna(CachingMixin, models.Model):
         xrefs = self.xrefs.filter(db__project_id__isnull=True, deleted='N')
         if taxid:
             xrefs = xrefs.filter(taxid=taxid)
-        return xrefs.count()        
+        return xrefs.count()
 
     @cached_property
     def count_distinct_organisms(self):
@@ -1224,6 +1224,22 @@ class Reference_map(models.Model):
 
     class Meta:
         db_table = 'rnc_reference_map'
+
+
+class SecondaryStructure(models.Model):
+    ss_id = models.AutoField(primary_key=True)
+    accession = models.ForeignKey(
+        Accession,
+        db_column='rnc_accession_id',
+        to_field='accession',
+        related_name='secondary_structure',
+    )
+    secondary_structure = models.TextField()
+    md5 = models.CharField(max_length=32, db_index=True)
+
+    class Meta:
+        db_table = 'rnc_secondary_structure'
+
 
 """
 Common auxiliary functions.

--- a/rnacentral/portal/models.py
+++ b/rnacentral/portal/models.py
@@ -1227,7 +1227,7 @@ class Reference_map(models.Model):
 
 
 class SecondaryStructure(models.Model):
-    ss_id = models.AutoField(primary_key=True)
+    id = models.AutoField(primary_key=True)
     accession = models.ForeignKey(
         Accession,
         db_column='rnc_accession_id',


### PR DESCRIPTION
As part of the GtRNAdb import we will be storing secondary structures.
This requires us to have a table to store the pairing information into
the database. This is a very simple table that will store the secondary
structure pairing information as a dot-bracket string. The secondary
structure is linked to an accession as the information comes from some
database. We allow for a single accession to have more than one
secondary structure, as this is possible. This does not contain any
information on the layout of the secondary structure (how to draw it) as
for now we will stick to something like forna to draw it.