### PR TITLE
Expand the Rfam classification when possible

### DIFF
--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -115,85 +115,88 @@ limitations under the License.
                     </ul>
                   {% endif %}
 
-                  {% if rna.grouped_rfam_hits|length > 0 %}
-                  <ul class="media-list">
-                  {% for hit in rna.grouped_rfam_hits %}
-                  <li class="media col-md-6" style="margin-bottom: 1.5em; padding-left: 5px;">
-                    <div class="media-left media-top col-md-3" style="padding-left: 0;"
-                      uib-tooltip="Consensus secondary structure of Rfam model {{ hit.rfam_model_id }}">
-                        <a href="{{ hit.rfam_model.twod_url }}" class="no-icon">
-                          <img class="media-object thumbnail"
-                            src="{{ hit.rfam_model.thumbnail_url }}"
-                            style="max-width: 120px; max-height: 120px;"
-                            alt="{{ hit.rfam_model_id }} secondary structure">
-                        </a>
-                    </div>
+                  {% with rna.grouped_rfam_hits as grouped_hits %}
+                    {% if grouped_hits|length > 0 %}
+                    <ul class="media-list">
+                    {% for hit in grouped_hits %}
+                    <li class="media {% if grouped_hits|length == 1 %} col-md-10 {% else %} col-md-6 {% endif %}" style="margin-bottom: 1.5em; padding-left: 5px;">
+                      <div class="media-left media-top {% if grouped_hits|length == 1 %} col-md-2 {% else %} col-md-3 {% endif %}" style="padding-left: 0;"
+                        uib-tooltip="Consensus secondary structure of Rfam model {{ hit.rfam_model_id }}">
+                          <a href="{{ hit.rfam_model.twod_url }}" class="no-icon">
+                            <img class="media-object thumbnail"
+                              src="{{ hit.rfam_model.thumbnail_url }}"
+                              style="max-width: 120px; max-height: 120px;"
+                              alt="{{ hit.rfam_model_id }} secondary structure">
+                          </a>
+                      </div>
 
-                    <div class="media-body">
-                      <h4 class="media-heading" style='padding-left: 0px;'>
-                        <a href="{{ hit.rfam_model.url }}">
-                          {{ hit.rfam_model.long_name }}
-                        </a>
-                      </h4>
+                      <div class="media-body">
+                        <h4 class="media-heading" style='padding-left: 0px;'>
+                          <a href="{{ hit.rfam_model.url }}">
+                            {{ hit.rfam_model.long_name }}
+                          </a>
+                        </h4>
 
-                      <ul class="list-unstyled">
-                        <li>
-                          {{ hit.rfam_model_id }}
-                          | {{ hit.rfam_model.rfam_rna_type }}
-                          {% if hit.rfam_model.domain != None %}
-                            | {{ hit.rfam_model.domain }}
-                          {% endif %}
-                          {% if hit.rfam_model.rna_type != "" %}
-                            | <span class="badge">{{ hit.rfam_model.rna_type }}</span>
-                          {% endif %}
-                        </li>
-                        <li>
-                          {% if hit.rfam_model.go_terms|length > 1 %}
-                          <ul class="list-unstyled">
-                            {% for go_term in hit.rfam_model.go_terms %}
-                            <li>
-                              <a href="{{ go_term.quickgo_url }}" target="_blank">{{ go_term.go_term_id }}</a>
-                              <small>{{ go_term.name }}</small>
-                            </li>
-                            {% endfor %}
-                          </ul>
-                          {% else %}
-                            {% with hit.rfam_model.go_terms.0 as go_term %}
-                              <a href="{{ go_term.quickgo_url }}">{{ go_term.go_term_id }}</a>
-                              <small>{{ go_term.name }}</small>
-                            {% endwith %}
-                          {% endif %}
-                        </li>
-                        {% with hit.ranges as ranges %}
-                          <li>Matches at{% if ranges|length == 1 %}:
-                                <strong>{{ ranges.0.0|add:"1"|intcomma }}-{{ ranges.0.1|intcomma }}</strong>
-                                ({% widthratio ranges.0.2 1 100 %}% of the model)
-                            {% else %}<a data-toggle="collapse"
-                                         href="#matchPositionsList-{{ forloop.counter }}"
-                                         aria-expanded="false"
-                                         aria-controls="matchPositionsList">
-                              <i class="fa fa-list" aria-hidden="true"></i> {{ ranges|length }} locations
-                            </a>
-                            <ul class='collapse list-unstyled' id='matchPositionsList-{{ forloop.counter }}'>
-                              {% for seq_start, seq_stop, ratio in hit.ranges %}
-                                <li style='padding-left: 1em;'>
-                                  <strong>{{ seq_start|add:"1"|intcomma }}-{{ seq_stop|intcomma }}</strong>
-                                  ({% widthratio ratio 1 100 %}% of the model)
-                                </li>
-                              {% endfor %}
-                              </ul>
+                        <ul class="list-unstyled">
+                          <li>
+                            {{ hit.rfam_model_id }}
+                            | {{ hit.rfam_model.rfam_rna_type }}
+                            {% if hit.rfam_model.domain != None %}
+                              | {{ hit.rfam_model.domain }}
+                            {% endif %}
+                            {% if hit.rfam_model.rna_type != "" %}
+                              | <span class="badge">{{ hit.rfam_model.rna_type }}</span>
                             {% endif %}
                           </li>
-                        {% endwith %}
-                      </ul>
+                          <li>
+                            {% if hit.rfam_model.go_terms|length > 1 %}
+                            <ul class="list-unstyled">
+                              {% for go_term in hit.rfam_model.go_terms %}
+                              <li>
+                                <a href="{{ go_term.quickgo_url }}" target="_blank">{{ go_term.go_term_id }}</a>
+                                <small>{{ go_term.name }}</small>
+                              </li>
+                              {% endfor %}
+                            </ul>
+                            {% else %}
+                              {% with hit.rfam_model.go_terms.0 as go_term %}
+                                <a href="{{ go_term.quickgo_url }}">{{ go_term.go_term_id }}</a>
+                                <small>{{ go_term.name }}</small>
+                              {% endwith %}
+                            {% endif %}
+                          </li>
 
-                    </div>
-                  </li>
-                  {% endfor %}
-                  </ul>
-                  {% else %}
-                    <p>The sequence did not match any Rfam families. <a href="{% url 'help-rfam-scan' %}">Learn more &rarr;</a></p>
-                  {% endif %}
+                          {% with hit.ranges as ranges %}
+                            <li>Matches at{% if ranges|length == 1 %}:
+                                  <strong>{{ ranges.0.0|add:"1"|intcomma }}-{{ ranges.0.1|intcomma }}</strong>
+                                  ({% widthratio ranges.0.2 1 100 %}% of the model)
+                              {% else %}<a data-toggle="collapse"
+                                           href="#matchPositionsList-{{ forloop.counter }}"
+                                           aria-expanded="false"
+                                           aria-controls="matchPositionsList">
+                                <i class="fa fa-list" aria-hidden="true"></i> {{ ranges|length }} locations
+                              </a>
+                              <ul class='collapse list-unstyled' id='matchPositionsList-{{ forloop.counter }}'>
+                                {% for seq_start, seq_stop, ratio in hit.ranges %}
+                                  <li style='padding-left: 1em;'>
+                                    <strong>{{ seq_start|add:"1"|intcomma }}-{{ seq_stop|intcomma }}</strong>
+                                    ({% widthratio ratio 1 100 %}% of the model)
+                                  </li>
+                                {% endfor %}
+                                </ul>
+                              {% endif %}
+                            </li>
+                          {% endwith %}
+                        </ul>
+
+                      </div>
+                    </li>
+                    {% endfor %}
+                    </ul>
+                    {% else %}
+                      <p>The sequence did not match any Rfam families. <a href="{% url 'help-rfam-scan' %}">Learn more &rarr;</a></p>
+                    {% endif %}
+                  {% endwith %}
                 </div>
 
                 <h2>


### PR DESCRIPTION
If we have a single Rfam match then the match should be allowed to take
up all the room. This is nice in cases where the GO term description is
long as this way it will not split into several lines unnecessarily. This
adds that functionality. Two examples are:

http://localhost:8000/rna/URS000080E226/274

and

http://localhost:8000/rna/URS00000478B7/9606

In the second there is a large space between the image and the text but
that is because that image is very narrow. Shrinking the space to the
text in that case makes the first case with a wide image look bad.

I've also added a with statement for the grouped hits as I end up using
it several times when detecting the classes.