### PR TITLE
Alter example search to use XIST #237

### DIFF
--- a/rnacentral/portal/static/js/components/text-search/text-search-bar/text-search-bar.html
+++ b/rnacentral/portal/static/js/components/text-search/text-search-bar/text-search-bar.html
@@ -35,7 +35,7 @@
       <span class="help-block example-searches">
           <i>
             Examples:
-            <a tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Search by gene name" href="" rel="nofollow" ng-click="$ctrl.search.search('&#40;&quot;HOTAIR&quot; OR &quot;HOX&quot;&#41; AND TAXONOMY:&quot;9606&quot; AND rna_type:&quot;lncRNA&quot; AND length:[500 to 3000]')">human HOTAIR</a>,
+            <a tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Search by gene name" href="" rel="nofollow" ng-click="$ctrl.search.search('&quot;XIST&quot; AND TAXONOMY:&quot;9606&quot;')">human XIST</a>,
             <a tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Search by species name or NCBI taxonomy ID" href="" rel="nofollow" ng-click="$ctrl.search.search('TAXONOMY:&quot;9606&quot;')">Homo sapiens</a>,
             <a tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Search by RNA type" href="" rel="nofollow" ng-click="$ctrl.search.search('rna_type:&quot;tRNA&quot;')">tRNA</a>,
             <a tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Search by Expert Database" href="" rel="nofollow" ng-click="$ctrl.search.search('expert_db:&quot;mirbase&quot;')">miRBase</a>,


### PR DESCRIPTION
Here is a simple change that uses XIST instead of HOTAIR. The results
look reasonable with a simple search. They are not ideal in that XIST
should be the first hit, but is actually the second.