### PR TITLE
Map more sequences to reference genomes

### DIFF
--- a/rnacentral/portal/management/commands/update_coordinate_names.py
+++ b/rnacentral/portal/management/commands/update_coordinate_names.py
@@ -1,0 +1,39 @@
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+    python manage.py update_coordinate_names
+    """
+    def handle(self, *args, **options):
+        """
+        Main function, called by django.
+        """
+        sql = """
+        UPDATE rnc_coordinates a
+        SET
+        	name = b.ensembl_name,
+        	primary_start = local_start,
+        	primary_end = local_end
+        FROM ensembl_insdc_mapping b
+        WHERE
+          a.primary_accession = b.insdc
+          AND a.name IS NULL
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(sql)

--- a/rnacentral/portal/management/commands/update_coordinate_names.py
+++ b/rnacentral/portal/management/commands/update_coordinate_names.py
@@ -27,9 +27,9 @@ class Command(BaseCommand):
         sql = """
         UPDATE rnc_coordinates a
         SET
-        	name = b.ensembl_name,
-        	primary_start = local_start,
-        	primary_end = local_end
+          name = b.ensembl_name,
+          primary_start = local_start,
+          primary_end = local_end
         FROM ensembl_insdc_mapping b
         WHERE
           a.primary_accession = b.insdc

--- a/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
+++ b/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
@@ -1,0 +1,121 @@
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from optparse import make_option
+from portal.models import Rna
+
+import pymysql.cursors
+
+
+def get_ensembl_connection():
+    """
+    Connect to the public Ensembl MySQL database.
+    """
+    connection = pymysql.connect(host='ensembldb.ensembl.org',
+                                 user='anonymous',
+                                 port=3306,
+                                 cursorclass=pymysql.cursors.DictCursor)
+    return connection
+
+
+def get_ensembl_databases(cursor):
+    """
+    Get a list of all available databases.
+    Return a list of the most recent core databases, for example:
+        homo_sapiens_core_91_38
+        mus_musculus_core_91_38
+    """
+    databases = defaultdict(list)
+    cursor.execute("show databases")
+    for result in cursor.fetchall():
+        database = result['Database']
+        if database.count('_') != 4 or 'mirror' in database:
+            continue
+        genus, species, database_type, ensembl_release, _ = database.split('_')
+        ensembl_release = int(ensembl_release)
+        if ensembl_release < 80:
+            continue
+        if database_type == 'core':
+            organism = genus + ' ' + species
+            databases[organism].append((ensembl_release, database))
+
+    to_analyse = []
+    # get the most recent database
+    for organism, dbs in databases.iteritems():
+        most_recent = max(dbs,key=lambda item:item[0])
+        to_analyse.append(most_recent[1])
+    return to_analyse
+
+
+def get_ensembl_insdc_mapping(cursor, database):
+    """
+    Get a mapping between chromosome-level INSDC accessions and Ensembl names.
+    Example:
+        CM001500.1	10
+        CM001492.1	2
+    """
+    mapping = []
+    cursor.execute("USE %s" % database)
+    sql = """
+    SELECT synonym AS insdc, name AS ensembl
+    FROM seq_region t1, seq_region_synonym t2, external_db t3
+    WHERE
+    t1.`seq_region_id` = t2.`seq_region_id`
+    AND t2.external_db_id = t3.`external_db_id`
+    AND t3.db_name = 'INSDC'
+    AND t1.`coord_system_id` in (
+        SELECT coord_system_id
+        FROM coord_system
+        WHERE name = 'chromosome'
+        AND attrib = 'default_version'
+    )
+    """
+    cursor.execute(sql)
+    for result in cursor.fetchall():
+        mapping.append({
+            'insdc': result['insdc'],
+            'ensembl': result['ensembl'],
+        })
+    return mapping
+
+
+def store_mapping(mapping):
+    """
+    """
+    for entry in mapping:
+        print '"{insdc}","{ensembl}"'.format(insdc=entry['insdc'],
+                                             ensembl=entry['ensembl'])
+
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+    python manage.py update_ensembl_genome_mapping
+    """
+    def handle(self, *args, **options):
+        """
+        Main function, called by django.
+        """
+        connection = get_ensembl_connection()
+        try:
+            with connection.cursor() as cursor:
+                databases = get_ensembl_databases(cursor)
+                for database in databases:
+                    mapping = get_ensembl_insdc_mapping(cursor, database)
+                    store_mapping(mapping)
+        finally:
+            connection.close()

--- a/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
+++ b/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
@@ -146,8 +146,8 @@ def store_ensembl_metadata(metadata):
     assembly = EnsemblAssembly(
         assembly_id=metadata['assembly.default'],
         assembly_full_name=metadata['assembly.name'],
-        gca_accession=metadata['assembly.accession'] if 'assembly.accession' in metadata else '',
-        assembly_ucsc=metadata['assembly.ucsc_alias'] if 'assembly.ucsc_alias' in metadata else '',
+        gca_accession=metadata['assembly.accession'] if 'assembly.accession' in metadata else None,
+        assembly_ucsc=metadata['assembly.ucsc_alias'] if 'assembly.ucsc_alias' in metadata else None,
         common_name=metadata['species.common_name'],
         taxid=metadata['species.taxonomy_id'],
     )

--- a/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
+++ b/rnacentral/portal/management/commands/update_ensembl_genome_mapping.py
@@ -92,12 +92,14 @@ def get_ensembl_insdc_mapping(cursor, database):
     return mapping
 
 
-def store_mapping(mapping):
+def store_mapping(mapping, ensembl_metadata):
     """
     """
+    assembly_id = ensembl_metadata['assembly.default']
     for entry in mapping:
-        print '"{insdc}","{ensembl}"'.format(insdc=entry['insdc'],
-                                             ensembl=entry['ensembl'])
+        print '"{insdc}","{ensembl}","{assembly_id}"'.format(insdc=entry['insdc'],
+            ensembl=entry['ensembl'],
+            assembly_id=assembly_id)
 
 
 def get_ensembl_metadata(cursor, database):
@@ -131,7 +133,7 @@ def get_ensembl_metadata(cursor, database):
 def store_ensembl_metadata(metadata):
     """
     """
-    line = "{assembly_id}\t{assembly_full_name}\t{GCA_accession}\t{common_name}\t{taxid}".format(
+    line = "{assembly_id}\t{assembly_full_name}\t{GCA_accession}\t{assembly_ucsc}\t{common_name}\t{taxid}".format(
         assembly_id=metadata['assembly.default'],
         GCA_accession=metadata['assembly.accession'] if 'assembly.accession' in metadata else '',
         assembly_full_name=metadata['assembly.name'],
@@ -157,9 +159,9 @@ class Command(BaseCommand):
             with connection.cursor() as cursor:
                 databases = get_ensembl_databases(cursor)
                 for database in databases:
-                    mapping = get_ensembl_insdc_mapping(cursor, database)
-                    store_mapping(mapping)
                     ensembl_metadata = get_ensembl_metadata(cursor, database)
-                    store_ensembl_metadata(ensembl_metadata)
+                    mapping = get_ensembl_insdc_mapping(cursor, database)
+                    store_mapping(mapping, ensembl_metadata)
+                    # store_ensembl_metadata(ensembl_metadata)
         finally:
             connection.close()

--- a/rnacentral/portal/migrations/0016_merge.py
+++ b/rnacentral/portal/migrations/0016_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0012_auto_20170818_1016'),
+        ('portal', '0015_auto_20170808_1633'),
+    ]
+
+    operations = [
+    ]

--- a/rnacentral/portal/migrations/0017_auto_20171214_1138.py
+++ b/rnacentral/portal/migrations/0017_auto_20171214_1138.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import caching.base
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0016_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EnsemblAssembly',
+            fields=[
+                ('assembly_id', models.CharField(max_length=255, serialize=False, primary_key=True)),
+                ('assembly_full_name', models.CharField(max_length=255, db_index=True)),
+                ('gca_accession', models.CharField(max_length=20, db_index=True)),
+                ('assembly_ucsc', models.CharField(max_length=100, db_index=True)),
+                ('common_name', models.CharField(max_length=255, db_index=True)),
+                ('taxid', models.IntegerField(db_index=True)),
+            ],
+            options={
+                'db_table': 'ensembl_assembly',
+            },
+            bases=(caching.base.CachingMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='EnsemblInsdcMapping',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('insdc', models.CharField(max_length=255, db_index=True)),
+                ('ensembl_name', models.CharField(max_length=255, db_index=True)),
+                ('assembly_id', models.ForeignKey(related_name='assembly', to='portal.EnsemblAssembly')),
+            ],
+            options={
+                'db_table': 'ensembl_insdc_mapping',
+            },
+            bases=(caching.base.CachingMixin, models.Model),
+        ),
+    ]

--- a/rnacentral/portal/migrations/0018_auto_20171214_1524.py
+++ b/rnacentral/portal/migrations/0018_auto_20171214_1524.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0017_auto_20171214_1138'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ensemblinsdcmapping',
+            name='assembly_id',
+            field=models.ForeignKey(related_name='assembly', db_column=b'assembly_id', to='portal.EnsemblAssembly'),
+        ),
+    ]

--- a/rnacentral/portal/migrations/0019_auto_20171214_1538.py
+++ b/rnacentral/portal/migrations/0019_auto_20171214_1538.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0018_auto_20171214_1524'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ensemblassembly',
+            name='assembly_ucsc',
+            field=models.CharField(max_length=100, null=True, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='ensemblassembly',
+            name='gca_accession',
+            field=models.CharField(max_length=20, null=True, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='ensemblassembly',
+            name='taxid',
+            field=models.IntegerField(unique=True, db_index=True),
+        ),
+    ]

--- a/rnacentral/portal/models/ensembl_assembly.py
+++ b/rnacentral/portal/models/ensembl_assembly.py
@@ -1,0 +1,29 @@
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from caching.base import CachingMixin, CachingManager
+from django.db import models
+
+
+class EnsemblAssembly(CachingMixin, models.Model):
+    assembly_id = models.CharField(primary_key=True, max_length=255)
+    assembly_full_name = models.CharField(max_length=255, db_index=True)
+    gca_accession = models.CharField(max_length=20, db_index=True)
+    assembly_ucsc = models.CharField(max_length=100, db_index=True)
+    common_name = models.CharField(max_length=255, db_index=True)
+    taxid = models.IntegerField(db_index=True)
+
+    objects = CachingManager()
+
+    class Meta:
+        db_table = 'ensembl_assembly'

--- a/rnacentral/portal/models/ensembl_assembly.py
+++ b/rnacentral/portal/models/ensembl_assembly.py
@@ -21,7 +21,7 @@ class EnsemblAssembly(CachingMixin, models.Model):
     gca_accession = models.CharField(max_length=20, db_index=True)
     assembly_ucsc = models.CharField(max_length=100, db_index=True)
     common_name = models.CharField(max_length=255, db_index=True)
-    taxid = models.IntegerField(db_index=True)
+    taxid = models.IntegerField(db_index=True, unique=True)
 
     objects = CachingManager()
 

--- a/rnacentral/portal/models/ensembl_assembly.py
+++ b/rnacentral/portal/models/ensembl_assembly.py
@@ -18,8 +18,8 @@ from django.db import models
 class EnsemblAssembly(CachingMixin, models.Model):
     assembly_id = models.CharField(primary_key=True, max_length=255)
     assembly_full_name = models.CharField(max_length=255, db_index=True)
-    gca_accession = models.CharField(max_length=20, db_index=True)
-    assembly_ucsc = models.CharField(max_length=100, db_index=True)
+    gca_accession = models.CharField(max_length=20, db_index=True, null=True)
+    assembly_ucsc = models.CharField(max_length=100, db_index=True, null=True)
     common_name = models.CharField(max_length=255, db_index=True)
     taxid = models.IntegerField(db_index=True, unique=True)
 

--- a/rnacentral/portal/models/ensembl_insdc_mapping.py
+++ b/rnacentral/portal/models/ensembl_insdc_mapping.py
@@ -18,7 +18,7 @@ from portal.models import EnsemblAssembly, GenomicCoordinates
 
 
 class EnsemblInsdcMapping(CachingMixin, models.Model):
-    assembly_id = models.ForeignKey(EnsemblAssembly, related_name='assembly')
+    assembly_id = models.ForeignKey(EnsemblAssembly, related_name='assembly', db_column='assembly_id')
     insdc = models.CharField(max_length=255, db_index=True)
     ensembl_name = models.CharField(max_length=255, db_index=True)
 

--- a/rnacentral/portal/models/ensembl_insdc_mapping.py
+++ b/rnacentral/portal/models/ensembl_insdc_mapping.py
@@ -11,20 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from accession import *
-from chemical_component import *
-from database import *
-from database_stats import *
-from formatters import *
-from genomic_coordinates import *
-from modification import *
-from reference import *
-from reference_map import *
-from release import *
-from rna import *
-from rna_precomputed import *
-from secondary_structure import *
-from xref import *
-from ensembl_assembly import *
-from ensembl_insdc_mapping import *
-from utils import get_ensembl_divisions
+from caching.base import CachingMixin, CachingManager
+from django.db import models
+
+from portal.models import EnsemblAssembly, GenomicCoordinates
+
+
+class EnsemblInsdcMapping(CachingMixin, models.Model):
+    assembly_id = models.ForeignKey(EnsemblAssembly, related_name='assembly')
+    insdc = models.CharField(max_length=255, db_index=True)
+    ensembl_name = models.CharField(max_length=255, db_index=True)
+
+    objects = CachingManager()
+
+    class Meta:
+        db_table = 'ensembl_insdc_mapping'


### PR DESCRIPTION
This PR uses the Ensembl MySQL database to map more RNAcentral accessions to reference genomes. Almost 300,000 additional exons are mapped to reference genomes, mostly from NONCODE, Rfam, and ENA. ✨

## 2 new tables

- _ensembl_assembly_. Example data: 

  ```
  GRCh38	GRCh38.p10	GCA_000001405.25	hg38	human	9606
  UMD2	Turkey_2.01	GCA_000146605.1	melGal1 turkey	9103
  ```

  Note that now we will have a reliable mapping between Ensembl and **UCSC** database names (e.g. melGal1).

- _ensembl_insdc_mapping_. Example data:

  ```
  1	CM000410.1	2	OANA5
  2	CM000412.1	4	OANA5
  ```

Now the _name_ field in the _rnc_coordinates_ table can be updated to `2` for all rows where `primary_accession` is `CM000410.1`.

## 2 new management commands

`python manage.py update_ensembl_genome_mapping` will update _ensembl_assembly_ and _ensembl_insdc_mapping_ tables. The command is **idempotent** and should be safe to run any number of times.

`python manage.py update_coordinate_names` will use the Ensembl-INSDC mapping to update name, primary_start and primary_end fields in the _rnc_coordinates_ table. This makes it possible to display genomic coordinates in Genoverse.

## How to test

Please take a look at the new tables on the DEV database.

Example entry that now has genome coordinates (make sure that the DEV database is used):
http://localhost:8000/rna/URS00006AD9B0/9606

## Future work

- The _ensembl_assembly_ table contains almost the same information as the `genomes.py` config object, **except** for example genome locations. 

- When working on #257 it might be worth updating the API to use the new table and deprecate `genomes.py`. 

- If this is extended to Ensembl Genomes then Genoverse can build proper Ensembl and Ensembl Genomes URLs for all species.