### PR TITLE
tRNA warnings improvements

### DIFF
--- a/rnacentral/portal/rfam_matches.py
+++ b/rnacentral/portal/rfam_matches.py
@@ -356,7 +356,7 @@ class MissingMatch(object):
             ]),
         }
 
-    def is_ignorable_mito_missing(self, rna, hits, taxid=None):
+    def is_ignorable_mito_missing_tRNA(self, rna, hits, taxid=None):
         if rna.get_rna_type() != 'tRNA':
             return False
 
@@ -377,7 +377,7 @@ class MissingMatch(object):
             return RfamMatchStatus.no_issues(rna.upi, taxid)
 
         hits = rna.get_rfam_hits()
-        if self.is_ignorable_mito_missing(rna, hits):
+        if self.is_ignorable_mito_missing_tRNA(rna, hits, taxid=taxid):
             return RfamMatchStatus.no_issues(rna.upi, taxid)
 
         required = self.expected_matches[rna_type]


### PR DESCRIPTION
There are some tRNA sequences that we create warnings for which we should not. For example:

A tRNA from HGNC found in mitochondria: http://localhost:8000/rna/URS000036D40A/9606
A tRNA in mitochondria, but not from HGNC: http://localhost:8000/rna/URS0000400378/59896

Basically this prevents warnings from happening, if a tRNA sequence has not Rfam matches and seems to occur in the mitochondria. 