### PR TITLE
Determine when sequences are mitochondrial

### DIFF
--- a/rnacentral/portal/management/commands/import_hgnc.py
+++ b/rnacentral/portal/management/commands/import_hgnc.py
@@ -143,11 +143,16 @@ class HGNCImporter():
             if entry['symbol']:
                 gene_description = ' (%s)' % entry['symbol']
 
+            organelle = None
+            if entry['location'] == 'mitochondria':
+                organelle = 'Mitochondrion'
+
             Accession.objects.update_or_create(
                 accession=entry['hgnc_id'],
                 description='Homo sapiens ' + entry['name'] + gene_description,
                 division='HUM',
                 species='Homo sapiens',
+                organelle=organelle,
                 is_composite='N',
                 database='HGNC',
                 classification='Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia; Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae; Homo; Homo sapiens',


### PR DESCRIPTION
In some cases (25 to be exact) HGNC can tell us that a molecule is
stored in the mitochondria. In those we store that information. Most of
the location entry is stuff like `7q32.1`, which is a position on a
nuclear chromosome. This is a minor improvement but does make the HGNC
annotations consistent with other databases in these cases, as
previously all other databases would state the molecule is found in the
mitochondria.