### PR TITLE
372 databases in popup

### DIFF
--- a/rnacentral/portal/static/js/components/genome-browser/genoverse-utils.service.js
+++ b/rnacentral/portal/static/js/components/genome-browser/genoverse-utils.service.js
@@ -172,7 +172,8 @@ angular.module("genomeBrowser").factory('GenoverseUtils', ['$filter', function($
                 "Feature type": feature.feature_type,
                 "Location": location,
                 "Logic name": feature.logic_name,
-                "Strand": strand
+                "Strand": strand,
+                "Databases": feature.databases.join(', ')
             };
         }, this);
 


### PR DESCRIPTION
Shows databases in Genoverse popups.

We still have N+1 requests issue here (a separate SQL query per each RNA upi), but this results in a halfway decent ~5 sec for moderately crowded genome locations. Compared to xrefs database-specific data, this doesn't seem to be the bottleneck anyways.

resolves #372 