### PR TITLE
Fixes #269

### DIFF
--- a/rnacentral/portal/tests/description_tests.py
+++ b/rnacentral/portal/tests/description_tests.py
@@ -15,7 +15,6 @@ import unittest
 
 from django.test import SimpleTestCase
 
-
 from django_performance_testing.queries import QueryBatchLimit
 from django_performance_testing.timing import TimeLimit
 
@@ -76,6 +75,12 @@ class SimpleDescriptionTests(GenericDescriptionTest):
             'Danio rerio tRNA',
             'URS0000661037',
             taxid=7955)
+
+    def test_cleans_up_tmrna_descriptions(self):
+        self.assertDescriptionIs(
+            'Homo sapiens (human) transfer-messenger RNA Esche_coli_K12',
+            'URS000037602E',
+            taxid=9606)
 
 
 class HumanDescriptionTests(GenericDescriptionTest):
@@ -142,12 +147,11 @@ class HumanDescriptionTests(GenericDescriptionTest):
             'URS000019E0CD',
             taxid=9606)
 
-    @pytest.mark.skip()
-    def test_uses_snopy_descriptions(self):
-        self.assertDescriptionIs(
-            'Homo sapiens (human) small nucleolar RNA SNORD118L8',
-            'URS00006CE02F',
-            taxid=9606)
+    # def test_uses_snopy_descriptions(self):
+    #     self.assertDescriptionIs(
+    #         'Homo sapiens (human) small nucleolar RNA SNORD118L8',
+    #         'URS00006CE02F',
+    #         taxid=9606)
 
 
 class ArabidopisDescriptionTests(GenericDescriptionTest):

--- a/rnacentral/portal/utils/descriptions/rule_method.py
+++ b/rnacentral/portal/utils/descriptions/rule_method.py
@@ -48,6 +48,7 @@ CHOICES = {
         'RGD',
         'lncRNAdb',
         'gtRNAdb',
+        'tmRNA Website',
         'PDBe',
         'RefSeq',
         'Rfam',


### PR DESCRIPTION
The issue was that we did not add the tmRNA database to ordering list of possible databases. This lead to the rule method never being applied and thus the issue with the names. 