### PR TITLE
Add json-ld definitions for DataCatalog and DataRecord

### DIFF
--- a/rnacentral/portal/templates/portal/homepage.html
+++ b/rnacentral/portal/templates/portal/homepage.html
@@ -309,15 +309,43 @@ $(document).ready(function() {
 </script>
 
 <script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "WebSite",
-  "url": "https://rnacentral.org/",
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": "https://rnacentral.org/search?q={search_term_string}",
-    "query-input": "required name=search_term_string"
-  }
-}
+[
+    {
+      "@context": "http://schema.org",
+      "@type": "WebSite",
+      "url": "https://rnacentral.org/",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://rnacentral.org/search?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@context" : "http://schema.org",
+      "@type" : "DataCatalog",
+      "description" : "RNAcentral is a comprehensive database of non-coding RNA sequences that represents all types of ncRNA from a broad range of organisms",
+      "keywords" : "non-coding RNA, ncRNA",
+      "name" : "RNAcentral database",
+      "url" : "https://rnacentral.org",
+      "publication" : [ {
+        "@type" : "PublicationEvent",
+        "name" : "RNAcentral: a comprehensive database of non-coding RNA sequences ",
+        "url" : "http://identifiers.org/pubmed:27794554"
+      } ],
+      "provider" : {
+        "@type" : "Organization",
+        "name" : "RNAcentral"
+      },
+      "sourceOrganization" : {
+        "@type" : "Organization",
+        "name" : "The European Bioinformatics Institute (EMBL-EBI)",
+        "url" : "https://www.ebi.ac.uk/"
+      },
+      "dataset" : [ {
+        "@type" : "Dataset",
+        "@id" : "https://rnacentral.org/downloads"
+      } ]
+    }
+]
 </script>
 {% endblock %}

--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -310,4 +310,28 @@ limitations under the License.
         </div> <!-- .tabbable -->
     </div> <!-- .col-md-12 -->
 </div> <!-- .row -->
+
+{% if context.taxid %}
+<script type="application/ld+json">
+{
+    "@context": [
+        {
+            "@base": "http://schema.org"
+        }
+    ],
+    "@type": "DataRecord",
+    "url": "https://rnacentral.org/rna/{{ rna.upi }}/{{ context.taxid }}",
+    "mainEntity": {
+        "@type": [
+            "RNA",
+            "BioChemEntity"
+        ],
+        "@id": "http://identifiers.org/rnacentral:{{ rna.upi }}_{{context.taxid}}",
+        "identifier": "{{ rna.upi }}_{{ context.taxid }}",
+        "name": "{{ context.description }}",
+        "url": "https://rnacentral.org/rna/{{ rna.upi }}/{{ context.taxid }}"
+    }
+}
+</script>
+{% endif %}
 {% endblock content %}


### PR DESCRIPTION
The JSON-LD passes validation (mostly, got 2 small errors because RNA is not defined in BioSchemas yet):
https://search.google.com/structured-data/testing-tool/u/0/