### PR TITLE
Display Ensembl Compara

### DIFF
--- a/rnacentral/apiv1/serializers.py
+++ b/rnacentral/apiv1/serializers.py
@@ -22,7 +22,7 @@ from rest_framework import serializers
 from portal.models import Rna, Xref, Reference,  Reference_map, ChemicalComponent, Database, DatabaseStats, Accession, \
     Release, Reference, Modification, RfamHit, RfamModel, RfamClan, RfamGoTerm, OntologyTerm, SequenceFeature, \
     EnsemblAssembly, EnsemblInsdcMapping, EnsemblKaryotype, GenomeMapping, \
-    ProteinInfo, EnsemblCompara, RnaPrecomputed
+    ProteinInfo, EnsemblCompara, RnaPrecomputed, SequenceRegion
 
 
 class RawPublicationSerializer(serializers.ModelSerializer):
@@ -548,4 +548,4 @@ class EnsemblComparaSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = EnsemblCompara
-        fields = ('ensembl_transcript_id', 'rnacentral_id', )
+        fields = ('ensembl_transcript_id', 'rnacentral_id')

--- a/rnacentral/apiv1/serializers.py
+++ b/rnacentral/apiv1/serializers.py
@@ -21,7 +21,8 @@ from rest_framework import serializers
 
 from portal.models import Rna, Xref, Reference,  Reference_map, ChemicalComponent, Database, DatabaseStats, Accession, \
     Release, Reference, Modification, RfamHit, RfamModel, RfamClan, RfamGoTerm, OntologyTerm, SequenceFeature, \
-    EnsemblAssembly, EnsemblInsdcMapping, EnsemblKaryotype, GenomeMapping, ProteinInfo
+    EnsemblAssembly, EnsemblInsdcMapping, EnsemblKaryotype, GenomeMapping, \
+    ProteinInfo, EnsemblCompara, RnaPrecomputed
 
 
 class RawPublicationSerializer(serializers.ModelSerializer):
@@ -534,3 +535,17 @@ class EnsemblKaryotypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = EnsemblKaryotype
         fields = ('karyotype', )
+
+
+class RnaPrecomputedSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RnaPrecomputed
+        fields = ('id', 'rna_type', 'description', 'databases')
+
+
+class EnsemblComparaSerializer(serializers.ModelSerializer):
+    rnacentral_id = RnaPrecomputedSerializer(source='urs_taxid')
+
+    class Meta:
+        model = EnsemblCompara
+        fields = ('ensembl_transcript_id', 'rnacentral_id', )

--- a/rnacentral/apiv1/urls.py
+++ b/rnacentral/apiv1/urls.py
@@ -37,6 +37,8 @@ urlpatterns = [
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/rfam-hits/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.RfamHitsAPIViewSet.as_view()), name='rna-rfam-hits'),
     # sequence features found in this RNAcentral
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/sequence-features/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.SequenceFeaturesAPIViewSet.as_view()), name='rna-sequence-features'),
+    # related sequences according to Ensembl Compara
+    url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/ensembl-compara/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.EnsemblComparaAPIViewSet.as_view()), name='rna-ensembl-compara'),
     # all literature citations associated with an RNAcentral id
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/publications/?$', cache_page(CACHE_TIMEOUT)(views.RnaPublicationsView.as_view()), name='rna-publications'),
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/publications/(?P<taxid>\d+)/?$',cache_page(CACHE_TIMEOUT)(views.RnaPublicationsView.as_view()), name='rna-publications'),

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -687,7 +687,7 @@ class LargerPagination(Pagination):
             },
             'count': self.page.paginator.count,
             'results': data,
-            "ensembl_compara_url": self.ensembl_compara_url,
+            'ensembl_compara_url': self.ensembl_compara_url,
             'ensembl_compara_status': self.ensembl_compara_status,
         })
 
@@ -697,7 +697,7 @@ class EnsemblComparaAPIViewSet(generics.ListAPIView):
     permission_classes = (AllowAny, )
     serializer_class = EnsemblComparaSerializer
     pagination_class = LargerPagination
-    ensembl_transcript_id = None
+    ensembl_transcript_id = ''
 
     def get_queryset(self):
         upi = self.kwargs['pk']
@@ -731,10 +731,10 @@ class EnsemblComparaAPIViewSet(generics.ListAPIView):
     def get_ensembl_compara_url(self):
         urs_taxid = self.kwargs['pk']+ '_' + self.kwargs['taxid']
         genome_region = SequenceRegion.objects.filter(urs_taxid__id=urs_taxid).first()
-        if genome_region:
+        if genome_region and self.ensembl_transcript_id:
             return 'http://www.ensembl.org/' + genome_region.assembly.ensembl_url + '/Gene/Compara_Tree?t=' + self.ensembl_transcript_id
         else:
-            return ''
+            return None
 
     def get_ensembl_compara_status(self):
         urs_taxid = self.kwargs['pk']+ '_' + self.kwargs['taxid']

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -700,10 +700,14 @@ class EnsemblComparaAPIViewSet(generics.ListAPIView):
     def get_queryset(self):
         upi = self.kwargs['pk']
         taxid = self.kwargs['taxid']
-        urs_taxid = EnsemblCompara.objects.filter(urs_taxid__id=upi+'_'+taxid).first()
+        self_urs_taxid = upi + '_' + taxid
+        urs_taxid = EnsemblCompara.objects.filter(urs_taxid__id=self_urs_taxid).first()
         if urs_taxid:
             self.ensembl_transcript_id = urs_taxid.ensembl_transcript_id
-            return EnsemblCompara.objects.filter(homology_id=urs_taxid.homology_id).order_by('urs_taxid__description').all()
+            return EnsemblCompara.objects.filter(homology_id=urs_taxid.homology_id)\
+                                         .exclude(urs_taxid=self_urs_taxid)\
+                                         .order_by('urs_taxid__description')\
+                                         .all()
         else:
             return []
 

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -39,12 +39,12 @@ from apiv1.serializers import RnaNestedSerializer, AccessionSerializer, Citation
                               RawPublicationSerializer, RnaSecondaryStructureSerializer, \
                               RfamHitSerializer, SequenceFeatureSerializer, \
                               EnsemblAssemblySerializer, EnsemblInsdcMappingSerializer, ProteinTargetsSerializer, \
-                              LncrnaTargetsSerializer
+                              LncrnaTargetsSerializer, EnsemblComparaSerializer
 
 from apiv1.renderers import RnaFastaRenderer, RnaGffRenderer, RnaGff3Renderer, RnaBedRenderer
 from portal.models import Rna, RnaPrecomputed, Accession, Xref, Database, DatabaseStats, RfamHit, EnsemblAssembly,\
     EnsemblInsdcMapping, GenomeMapping, GenomicCoordinates, GoAnnotation, RelatedSequence, ProteinInfo, SequenceFeature,\
-    SequenceRegion
+    SequenceRegion, EnsemblCompara
 from portal.config.expert_databases import expert_dbs
 from rnacentral.utils.pagination import Pagination, PaginatedRawQuerySet
 
@@ -672,3 +672,19 @@ class LncrnaTargetsView(generics.ListAPIView):
         )
         queryset = PaginatedRawQuerySet(protein_info_query, model=ProteinInfo)
         return queryset
+
+
+class EnsemblComparaAPIViewSet(generics.ListAPIView):
+    """API endpoint for related sequences identified by Ensembl Compara"""
+    permission_classes = (AllowAny, )
+    serializer_class = EnsemblComparaSerializer
+    pagination_class = Pagination
+
+    def get_queryset(self):
+        upi = self.kwargs['pk']
+        taxid = self.kwargs['taxid']
+        urs_taxid = EnsemblCompara.objects.filter(urs_taxid__id=upi+'_'+taxid).first()
+        if urs_taxid:
+            return EnsemblCompara.objects.filter(homology_id=urs_taxid.homology_id).all()
+        else:
+            return []

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -674,17 +674,21 @@ class LncrnaTargetsView(generics.ListAPIView):
         return queryset
 
 
+class LargerPagination(Pagination):
+    page_size = 50
+
+
 class EnsemblComparaAPIViewSet(generics.ListAPIView):
     """API endpoint for related sequences identified by Ensembl Compara"""
     permission_classes = (AllowAny, )
     serializer_class = EnsemblComparaSerializer
-    pagination_class = Pagination
+    pagination_class = LargerPagination
 
     def get_queryset(self):
         upi = self.kwargs['pk']
         taxid = self.kwargs['taxid']
         urs_taxid = EnsemblCompara.objects.filter(urs_taxid__id=upi+'_'+taxid).first()
         if urs_taxid:
-            return EnsemblCompara.objects.filter(homology_id=urs_taxid.homology_id).all()
+            return EnsemblCompara.objects.filter(homology_id=urs_taxid.homology_id).order_by('urs_taxid__description').all()
         else:
             return []

--- a/rnacentral/portal/models/__init__.py
+++ b/rnacentral/portal/models/__init__.py
@@ -37,3 +37,4 @@ from .related_sequences import *
 from .sequence_features import *
 from .sequence_regions import *
 from .sequence_exons import *
+from .ensembl_compara import *

--- a/rnacentral/portal/models/ensembl_compara.py
+++ b/rnacentral/portal/models/ensembl_compara.py
@@ -1,0 +1,27 @@
+"""
+Copyright [2009-2019] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from caching.base import CachingMixin, CachingManager
+from django.db import models
+
+
+class EnsemblCompara(CachingMixin, models.Model):
+    id = models.IntegerField(primary_key=True)
+    ensembl_transcript_id = models.TextField()
+    urs_taxid = models.ForeignKey(models.RnaPrecomputed, to_field='id')
+    homology_id = models.IntegerField()
+
+    objects = CachingManager()
+
+    class Meta:
+        db_table = 'ensembl_compara'

--- a/rnacentral/portal/models/ensembl_compara.py
+++ b/rnacentral/portal/models/ensembl_compara.py
@@ -14,11 +14,13 @@ limitations under the License.
 from caching.base import CachingMixin, CachingManager
 from django.db import models
 
+from portal.models import RnaPrecomputed
+
 
 class EnsemblCompara(CachingMixin, models.Model):
     id = models.IntegerField(primary_key=True)
     ensembl_transcript_id = models.TextField()
-    urs_taxid = models.ForeignKey(models.RnaPrecomputed, to_field='id')
+    urs_taxid = models.ForeignKey(RnaPrecomputed, to_field='id', db_column='urs_taxid')
     homology_id = models.IntegerField()
 
     objects = CachingManager()

--- a/rnacentral/portal/static/js/components/routes.service.js
+++ b/rnacentral/portal/static/js/components/routes.service.js
@@ -20,6 +20,7 @@ angular.module("routes", []).service('routes', ['$interpolate', function($interp
         textSearch: 'search',
         expertDbLogo: '/static/img/expert-db-logos/{{ expertDbName }}.png',
         apiSecondaryStructuresView: '/api/v1/rna/{{ upi }}/2d/{{ taxid }}',
+        apiEnsemblComparaView: '/api/v1/rna/{{ upi }}/ensembl-compara/{{ taxid }}',
         genomesApi: '/api/v1/genomes/{{ ensemblAssembly }}',
         proxy: '/api/internal/proxy?url={{ url }}',
         ebiSearch:

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -45,6 +45,14 @@ var ensemblCompara = {
         ctrl.loadMoreResults = function() {
             ctrl.displayResults(ctrl.next_page);
         };
+
+        ctrl.has_same_urs = function(rnacentral_id) {
+            if (rnacentral_id.indexOf(ctrl.upi) === -1) {
+                return false;
+            } else {
+                return true;
+            }
+        }
     }],
 
     templateUrl: '/static/js/components/sequence/ensembl-compara/ensembl-compara.html'

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -11,6 +11,7 @@ var ensemblCompara = {
         ctrl.count = 0;
         ctrl.next_page = null;
         ctrl.ensembl_compara = [];
+        ctrl.ensembl_compara_url = '';
 
         ctrl.$onInit = function() {
             ctrl.displayResults();
@@ -22,6 +23,7 @@ var ensemblCompara = {
                     ctrl.ensembl_compara = ctrl.ensembl_compara.concat(response.data.results);
                     ctrl.count = response.data.count;
                     ctrl.next_page = response.data.next;
+                    ctrl.ensembl_compara_url = response.data.ensembl_compara_url;
                 },
                 function(response) {
                     ctrl.error = "Failed to fetch Ensembl Compara annotations";

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -12,6 +12,7 @@ var ensemblCompara = {
         ctrl.next_page = null;
         ctrl.ensembl_compara = [];
         ctrl.ensembl_compara_url = '';
+        ctrl.ensembl_compara_status = '';
 
         ctrl.$onInit = function() {
             ctrl.displayResults();
@@ -24,6 +25,7 @@ var ensemblCompara = {
                     ctrl.count = response.data.count;
                     ctrl.next_page = response.data.links.next;
                     ctrl.ensembl_compara_url = response.data.ensembl_compara_url;
+                    ctrl.ensembl_compara_status = response.data.ensembl_compara_status;
                 },
                 function(response) {
                     ctrl.error = "Failed to fetch Ensembl Compara annotations";

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -54,7 +54,16 @@ var ensemblCompara = {
             } else {
                 return true;
             }
-        }
+        };
+
+        ctrl.is_paralog = function(rnacentral_id) {
+            taxid = rnacentral_id.split('_')[1];
+            if (taxid === ctrl.taxid) {
+                return true;
+            } else {
+                return false;
+            }
+        };
     }],
 
     templateUrl: '/static/js/components/sequence/ensembl-compara/ensembl-compara.html'

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -1,0 +1,51 @@
+var ensemblCompara = {
+    bindings: {
+        upi: '=',
+        taxid: '=',
+    },
+
+    controller: ['$http', 'routes', function($http, routes) {
+        var ctrl = this;
+
+        ctrl.error = null;
+        ctrl.count = 0;
+        ctrl.next_page = null;
+        ctrl.ensembl_compara = [];
+
+        ctrl.$onInit = function() {
+            ctrl.displayResults();
+        };
+
+        ctrl.displayResults = function(next_page_url) {
+            ctrl.fetchEnsemblCompara(next_page_url).then(
+                function(response) {
+                    ctrl.ensembl_compara = ctrl.ensembl_compara.concat(response.data.results);
+                    ctrl.count = response.data.count;
+                    ctrl.next_page = response.data.next;
+                },
+                function(response) {
+                    ctrl.error = "Failed to fetch Ensembl Compara annotations";
+                }
+            );
+        };
+
+        ctrl.fetchEnsemblCompara = function(next_page_url) {
+            if (typeof next_page_url === 'undefined') {
+                return $http.get(
+                    routes.apiEnsemblComparaView({ upi: ctrl.upi, taxid: ctrl.taxid }),
+                    { timeout: 20000 }
+                );
+            } else {
+                return $http.get(next_page_url, { timeout: 20000 });
+            }
+        };
+
+        ctrl.loadMoreResults = function() {
+            ctrl.displayResults(ctrl.next_page);
+        };
+    }],
+
+    templateUrl: '/static/js/components/sequence/ensembl-compara/ensembl-compara.html'
+};
+
+angular.module("rnaSequence").component("ensemblCompara", ensemblCompara);

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.component.js
@@ -22,7 +22,7 @@ var ensemblCompara = {
                 function(response) {
                     ctrl.ensembl_compara = ctrl.ensembl_compara.concat(response.data.results);
                     ctrl.count = response.data.count;
-                    ctrl.next_page = response.data.next;
+                    ctrl.next_page = response.data.links.next;
                     ctrl.ensembl_compara_url = response.data.ensembl_compara_url;
                 },
                 function(response) {

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -30,7 +30,7 @@
 
 <div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
 
-    <p class="text-muted">
+    <p>
       This RNA has <strong>{{ $ctrl.count }}</strong> ortholog/paralog
       <ng-pluralize count="$ctrl.count"
                     when="{'1': 'sequence',

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -1,0 +1,37 @@
+<div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
+
+    <h2>
+      Ensembl Compara
+      <small>
+        <span>{{ $ctrl.count }} total</span>
+
+        <a href="" uib-tooltip="Learn more about Ensembl Compara annotations in RNAcentral &rarr;" style="color:inherit;">
+          <i class="fa fa-question-circle" aria-hidden="true"></i>
+        </a>
+      </small>
+    </h2>
+
+    <div class="force-scrollbars" style="max-height: 300px; overflow-y: scroll;">
+
+      <ul>
+        <li ng-repeat="entry in $ctrl.ensembl_compara">
+          <a href="/rna/{{ entry.rnacentral_id.id }}">{{ entry.rnacentral_id.description }}</a>
+        </li>
+      </ul>
+
+      <a href="" class="btn btn-default btn-sm" ng-click="$ctrl.loadMoreResults()" ng-if="$ctrl.count != $ctrl.ensembl_compara.length">Load more</a>
+
+      <span ng-if="$ctrl.error">
+        <i class="fa fa-exclamation-circle fa-2x"></i>
+        Failed to load data from server
+      </span>
+
+    </div>
+
+    <span>
+      View tree in
+      <a href="http://www.ensembl.org/Nomascus_leucogenys/Gene/Compara_Tree?g=ENSNLEG00000021462;r=1a:22821011-22821081;t=ENSNLET00000026487" target="_blank">Ensembl</a>
+      <!-- http://www.ensembl.org/Nomascus_leucogenys/Gene/Compara_Tree?t=<transcript_id> -->
+    </span>
+
+</div>

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -40,3 +40,9 @@
     </div>
 
 </div>
+
+<div ng-if="$ctrl.error" class="alert alert-danger">
+  <p>
+      {{ $ctrl.error }}
+  </p>
+</div>

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -1,19 +1,29 @@
 <div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
 
     <h2>
-      Ensembl Compara
+      Related sequences
       <small>
-        <span>{{ $ctrl.count }} total</span>
-
         <a href="https://www.ensembl.org/info/genome/compara/ncRNA_methods.html" class="no-icon" uib-tooltip="Learn about Ensembl Compara ncRNA trees &rarr;" style="color:inherit;" target="_blank">
           <i class="fa fa-question-circle" aria-hidden="true"></i>
         </a>
       </small>
     </h2>
 
+    <p class="text-muted">
+      This RNA has <strong>{{ $ctrl.count }}</strong> ortholog/paralog
+      <ng-pluralize count="$ctrl.count"
+                    when="{'1': 'sequence',
+                           'other': 'sequences'}">
+      </ng-pluralize>
+      identified by <strong>Ensembl Compara</strong>
+      <a ng-if="$ctrl.ensembl_compara_url" class="btn btn-sm btn-default margin-left-5px" href="{{ $ctrl.ensembl_compara_url }}" target="_blank">
+        <i class="fa fa-sitemap"></i> View ncRNA tree
+      </a>
+    </p>
+
     <div class="force-scrollbars" style="max-height: 300px; overflow-y: scroll;">
 
-      <ul>
+      <ul class="margin-bottom-5px">
         <li ng-repeat="entry in $ctrl.ensembl_compara">
           <a href="/rna/{{ entry.rnacentral_id.id }}">{{ entry.rnacentral_id.description }}</a>
         </li>
@@ -27,9 +37,5 @@
       </span>
 
     </div>
-
-    <p ng-if="$ctrl.ensembl_compara_url">
-      View <a href="{{ $ctrl.ensembl_compara_url }}" target="_blank">Ensembl Compara tree</a>
-    </p>
 
 </div>

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -1,13 +1,34 @@
-<div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
+<h2>
+  Related RNAs in other species
+  <small>
+    <a href="https://www.ensembl.org/info/genome/compara/ncRNA_methods.html" class="no-icon" uib-tooltip="Learn about Ensembl Compara ncRNA trees &rarr;" style="color:inherit;" target="_blank">
+      <i class="fa fa-question-circle" aria-hidden="true"></i>
+    </a>
+  </small>
+</h2>
 
-    <h2>
-      Related RNAs in other species
-      <small>
-        <a href="https://www.ensembl.org/info/genome/compara/ncRNA_methods.html" class="no-icon" uib-tooltip="Learn about Ensembl Compara ncRNA trees &rarr;" style="color:inherit;" target="_blank">
-          <i class="fa fa-question-circle" aria-hidden="true"></i>
-        </a>
-      </small>
-    </h2>
+<div ng-if="!$ctrl.ensembl_compara_status && !$ctrl.error">
+    <span>
+        <i class="fa fa-spinner fa-spin fa-2x"></i>
+        Loading related sequences...
+    </span>
+</div>
+
+<div ng-if="$ctrl.ensembl_compara.length === 0 && !$ctrl.error">
+  <p ng-if="$ctrl.ensembl_compara_status === 'analysis not available'">
+      This information is only available for <strong>Ensembl</strong> sequences
+      from certain RNA types annotated by <strong>Rfam</strong>
+      and <strong>miRBase</strong>.
+  </p>
+  <p ng-if="$ctrl.ensembl_compara_status === 'RNA type not supported'">
+      This information is not available for this RNA type.
+  </p>
+  <p ng-if="$ctrl.ensembl_compara_status === 'not found'">
+      No related sequences found.
+  </p>
+</div>
+
+<div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
 
     <p class="text-muted">
       This RNA has <strong>{{ $ctrl.count }}</strong> ortholog/paralog

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -1,7 +1,7 @@
 <div ng-if="$ctrl.ensembl_compara.length > 0 && !$ctrl.error">
 
     <h2>
-      Related sequences
+      Related RNAs in other species
       <small>
         <a href="https://www.ensembl.org/info/genome/compara/ncRNA_methods.html" class="no-icon" uib-tooltip="Learn about Ensembl Compara ncRNA trees &rarr;" style="color:inherit;" target="_blank">
           <i class="fa fa-question-circle" aria-hidden="true"></i>
@@ -26,6 +26,7 @@
       <ul class="margin-bottom-5px">
         <li ng-repeat="entry in $ctrl.ensembl_compara">
           <a href="/rna/{{ entry.rnacentral_id.id }}">{{ entry.rnacentral_id.description }}</a>
+          <span class="badge" ng-if="$ctrl.has_same_urs(entry.rnacentral_id.id)">identical sequence</span>
         </li>
       </ul>
 

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -48,6 +48,7 @@
         <li ng-repeat="entry in $ctrl.ensembl_compara">
           <a href="/rna/{{ entry.rnacentral_id.id }}">{{ entry.rnacentral_id.description }}</a>
           <span class="badge" ng-if="$ctrl.has_same_urs(entry.rnacentral_id.id)">identical sequence</span>
+          <span class="label label-success" ng-if="$ctrl.is_paralog(entry.rnacentral_id.id)">paralog</span>
         </li>
       </ul>
 

--- a/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
+++ b/rnacentral/portal/static/js/components/sequence/ensembl-compara/ensembl-compara.html
@@ -5,7 +5,7 @@
       <small>
         <span>{{ $ctrl.count }} total</span>
 
-        <a href="" uib-tooltip="Learn more about Ensembl Compara annotations in RNAcentral &rarr;" style="color:inherit;">
+        <a href="https://www.ensembl.org/info/genome/compara/ncRNA_methods.html" class="no-icon" uib-tooltip="Learn about Ensembl Compara ncRNA trees &rarr;" style="color:inherit;" target="_blank">
           <i class="fa fa-question-circle" aria-hidden="true"></i>
         </a>
       </small>
@@ -28,10 +28,8 @@
 
     </div>
 
-    <span>
-      View tree in
-      <a href="http://www.ensembl.org/Nomascus_leucogenys/Gene/Compara_Tree?g=ENSNLEG00000021462;r=1a:22821011-22821081;t=ENSNLET00000026487" target="_blank">Ensembl</a>
-      <!-- http://www.ensembl.org/Nomascus_leucogenys/Gene/Compara_Tree?t=<transcript_id> -->
-    </span>
+    <p ng-if="$ctrl.ensembl_compara_url">
+      View <a href="{{ $ctrl.ensembl_compara_url }}" target="_blank">Ensembl Compara tree</a>
+    </p>
 
 </div>

--- a/rnacentral/portal/templates/portal/base.html
+++ b/rnacentral/portal/templates/portal/base.html
@@ -198,6 +198,7 @@ limitations under the License.
             <script src="{% static "js/components/sequence/xrefs/xref-publications/xref-publications.component.js" %}"></script>
             <script src="{% static "js/components/sequence/2d/2d.component.js" %}"></script>
             <script src="{% static "js/components/sequence/go-annotations/go-annotations.component.js" %}"></script>
+            <script src="{% static "js/components/sequence/ensembl-compara/ensembl-compara.component.js" %}"></script>
             <script src="{% static "js/components/sequence/xrefs/mirbase-word-cloud/mirbase-word-cloud.component.js" %}"></script>
             <script src="{% static "js/components/sequence/protein-targets/protein-targets.component.js" %}"></script>
             <script src="{% static "js/components/sequence/lncrna-targets/lncrna-targets.component.js" %}"></script>

--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -208,6 +208,9 @@ limitations under the License.
                   <p>
                 </div>
 
+                <div>
+                  <ensembl-compara upi="upi" taxid="taxid"></ensembl-compara>
+                </div>
 
                 <div ng-hide="hideGoAnnotations" ng-if="taxid">
                   <h2>


### PR DESCRIPTION
**Features**
✅ links to Ensembl Compara tree
✅ paginates after 50 sequences
✅ identical sequences marked with a badge

**Examples**
- Many related sequences (supports pagination): http://localhost:8000/rna/URS0000001EB3/9606
- Only one related sequence: http://localhost:8000/rna/URS0000001A7A/9606
- No related sequences (nothing is shown): http://localhost:8000/rna/URS000075D95B/9606

⚠️ Do not merge until the production databases have the Compara tables ⚠️ 

@blakesweeney Please review on a local machine using the _TST_ database when you get a chance. Thanks!

Fixes #445, closes #342, and closes #32.