### PR TITLE
Begin work on differentiating URS pages from URS_taxid pages

### DIFF
--- a/jenkins/refresh-pub-vdbs.jenkinsfile
+++ b/jenkins/refresh-pub-vdbs.jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     }
     stages {
         stage("Copy local settings to Jenkins environment") {
+            // This is really stupid, but otherwise Django would miss settings and wouldn't boot
             environment {
                 LOCAL_SETTINGS = credentials('local_settings.py')
                 DATABASE = credentials('database_pro.py')
@@ -41,11 +42,11 @@ pipeline {
                 expression { params.DATABASE == 'FB1' || params.DATABASE == 'BOTH' }
             }
             environment {
-                KEYFILE = credentials('fb1-001-rsa')
+                USERPASSWORD = credentials('refresh_vdbs_login')
+                USER = "${env.USERPASSWORD_USR}"
+                PASSWORD = "${env.USERPASSWORD_PSW}"
             }
             steps {
-                sh "cat $KEYFILE > fb1-001-rsa"
-
                 // Note that we're using the virtualenv from .rnacentral-live virtualenv,
                 // which might get a bit crazy, but this is just for fabric python package.
                 sh '''
@@ -53,7 +54,7 @@ pipeline {
                     source local/virtualenvs/RNAcentral/bin/activate
                     popd
                     cd rnacentral
-                    fab fb1:key=../fb1-001-rsa refresh_fb1
+                    fab fb1 --password=$PASSWORD refresh_fb1
                 '''
             }
         }

--- a/rnacentral/fabfile.py
+++ b/rnacentral/fabfile.py
@@ -286,17 +286,16 @@ def test(base_url='http://localhost:8000/'):
 
 # VDBS refresh-related code
 
-def fb1(key):
+def fb1():
     """
     Configures environment variables for running commands on fb1, e.g.:
 
     fab fb1:key=/path/to/keyfile refresh_fb1
     """
     env.hosts = ['fb1-001.ebi.ac.uk']
-    env.user = 'burkov'
+    env.user = 'apetrov'
     env.run = run
     env.cd = cd
-    env.key_filename = key
 
 
 def pg():
@@ -306,7 +305,7 @@ def pg():
     fab pg --password=mytopsecretpassword refresh_pg
     """
     env.hosts = ['pg-001.ebi.ac.uk']
-    env.user = 'burkov'
+    env.user = 'apetrov'
     env.run = run
     env.cd = cd
 

--- a/rnacentral/portal/models/rna.py
+++ b/rnacentral/portal/models/rna.py
@@ -607,8 +607,6 @@ class Rna(CachingMixin, models.Model):
         return data
 
     def get_annotations_from_other_species(self, taxid=None):
-        if not taxid:
-            return []
         query = '''
         SELECT t1.id AS urs_taxid, t1.short_description, t2.name as species_name
         FROM {rna_precomputed} t1, rnc_taxonomy t2
@@ -620,10 +618,12 @@ class Rna(CachingMixin, models.Model):
         ORDER BY description
         LIMIT 10000
         '''.format(urs=self.upi,
-                   taxid=taxid,
+                   taxid=taxid if taxid else 0,
                    rna_precomputed=RnaPrecomputed._meta.db_table
         )
         with connection.cursor() as cursor:
             cursor.execute(query)
             data = dictfetchall(cursor)
+        for entry in data:
+            entry['urs_taxid'] = entry['urs_taxid'].replace('_', '/')
         return data

--- a/rnacentral/portal/templates/portal/sequence-no-species.html
+++ b/rnacentral/portal/templates/portal/sequence-no-species.html
@@ -1,0 +1,98 @@
+<!--
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% extends "portal/base.html" %}
+{% load staticfiles %}
+{% load humanize %}
+
+{% block meta_tags %}
+    {{ block.super }}
+    <meta name="description" content="{{ context.description }} | {{ rna.upi }}"/>
+    <meta name="twitter:description" content="{{ context.description }} | {{ rna.upi }}">
+{% endblock %}
+
+{% block title %}
+  {{ context.description }} | {{ rna.upi.upi }}
+{% endblock %}
+
+{% block content %}
+<div class="row" ng-controller="rnaSequenceController">
+    <div class="col-md-12">
+        <h1>
+            Sequence {{ rna.upi }}
+            <small>{{ rna.length|intcomma }} nucleotides</small>
+        </h1>
+
+        <div class="alert alert-success col-md-6 clearfix">
+            <p>
+              {{ rna.upi }} is a <strong>{{ context.precomputed.rna_type }}</strong>
+              found in <strong>{{ rna.count_distinct_organisms|intcomma }} species</strong>
+            </p>
+        </div>
+
+        {% if context.annotations_from_other_species %}
+        <div class="margin-bottom-10px">
+          <h3>
+            <strong>Choose an organism</strong> to see detailed,
+            species-specific information
+          </h3>
+          <div style="max-height: 500px; overflow:auto;" class="force-scrollbars">
+            <ul>
+            {% for entry in context.annotations_from_other_species %}
+              <li class="lead margin-bottom-5px">{{ entry.species_name }} <a href="/rna/{{ entry.urs_taxid }}" rel="canonical">{{ entry.short_description }}</a></li>
+            {% endfor %}
+            </ul>
+          </div>
+        </div>
+        {% endif %}
+
+        <h4>Taxonomic tree</h4>
+        <div class="panel panel-default d3-species">
+            <div class="tab-pane panel-body d3-species force-scrollbars d3-species-tree-tab">
+                <taxonomy upi="upi"></taxonomy>
+            </div>
+        </div>
+
+        <h3>Sequence</h3>
+
+        {% if context.non_canonical_base_counts %}
+        <p class="small">
+            <span class="text-warning"><i class="fa fa-warning"></i> Contains ambiguity characters:</span> {% for symbol,count in context.non_canonical_base_counts.items %}{{ count|intcomma }} {{ symbol }}{% if not forloop.last %}, {% endif %}{% endfor %}
+            <a href="https://en.wikipedia.org/wiki/Nucleic_acid_notation#IUPAC_notation">&nbsp;IUPAC notation</a>
+        </p>
+        {% endif %}
+
+        <div style="padding-top: 10px; padding-bottom: 10px;">
+            <div class="btn-group">
+                <button class="btn btn-default" id="copy-as-rna">
+                  <i class="fa fa-copy" aria-hidden="true"></i> Copy as RNA
+                </button>
+                <button class="btn btn-default" id="copy-as-dna">
+                  <i class="fa fa-copy" aria-hidden="true"></i> Copy as DNA
+                </button>
+            </div>
+            <div class="btn-group">
+                  <a class="btn btn-default" ng-click="download('fasta')">Download FASTA</a>
+                  <a class="btn btn-default" ng-click="download('json')">Download JSON</a>
+            </div>
+            <a class="btn btn-default" href="{% url 'nhmmer-sequence-search' %}?q={{ rna.upi }}" class="margin-left-5px">
+              <i class="fa fa-search" aria-hidden="true"></i> Search for similar sequences
+            </a>
+        </div>
+
+        <pre class="pre-scrollable" id="rna-sequence">{{ rna.get_sequence }}</pre>
+
+    </div> <!-- .col-md-12 -->
+</div> <!-- .row -->
+
+{% endblock content %}

--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -34,9 +34,9 @@ limitations under the License.
     </div>
     <div ng-if="rna" class="col-md-12">
         <h1>
-            Sequence {{ rna.upi }}
+            {{ context.description }}
 
-            <small id="sequence-description-header">{{ context.description }}</small>
+            <!-- <small id="sequence-description-header">{{ context.description }}</small> -->
         </h1>
 
         {% if context.taxid_not_found %}
@@ -47,7 +47,7 @@ limitations under the License.
 
         <ul class="list-inline" id="sequence-overview">
             <li><strong>{{ rna.length|intcomma }}</strong> nucleotides</li>
-            <li>
+            <li ng-if="taxid">
                 {% with dbs=context.distinct_databases %}
                 <strong>{{ dbs|length|intcomma }}</strong> database{{ dbs|length|pluralize }}
                 <small>
@@ -57,9 +57,10 @@ limitations under the License.
                 </small>
                 {% endwith %}
             </li>
-            <li>
+            <li ng-if="taxid">
                 Found in <strong>{{ rna.count_distinct_organisms|intcomma }}</strong> <a href="" class="show-species-tab" ng-click="activateTab('1')">species</a>
             </li>
+            <li uib-tooltip="Unique RNA Sequence identifier assigned by RNAcentral">{{rna.upi}}{% if context.taxid %}_{{ context.taxid }}{% endif %}</li>
             <li class="badge" style="padding-left: 7px; padding-right: 7px;">{{ context.precomputed.rna_type }}</li>
         </ul>
 
@@ -69,11 +70,34 @@ limitations under the License.
 
             <uib-tab index="0" heading="Overview" id="overview" deselect="checkTab($event, $selectedIndex)">
 
-                <xrefs upi="upi" taxid="taxid" timeout="500" page-size="5" on-activate-publications="activatePublications()" on-create-modifications-feature="createModificationsFeature(modifications, accession)" on-activate-genome-browser="activateGenomeBrowser(start, end, chr, genome)" on-scroll-to-genome-browser="scrollToGenomeBrowser()"></xrefs>
+                <xrefs ng-if="taxid" upi="upi" taxid="taxid" timeout="500" page-size="5" on-activate-publications="activatePublications()" on-create-modifications-feature="createModificationsFeature(modifications, accession)" on-activate-genome-browser="activateGenomeBrowser(start, end, chr, genome)" on-scroll-to-genome-browser="scrollToGenomeBrowser()"></xrefs>
 
                 <protein-targets ng-if="taxid" upi="upi" taxid="taxid" timeout="500" page-size="5" genomes="genomes"></protein-targets>
 
                 <lncrna-targets ng-if="taxid" upi="upi" taxid="taxid" timeout="500" page-size="5" genomes="genomes"></lncrna-targets>
+
+                {% if context.annotations_from_other_species and not context.taxid %}
+                <div>
+                  <h2>Found in {{ rna.count_distinct_organisms|intcomma }} species</h2>
+                  <p>
+                    View <strong>species-specific</strong> information:
+                  </p>
+                  <div style="max-height: 400px; overflow:auto;" class="force-scrollbars">
+                    <ol>
+                    {% for entry in context.annotations_from_other_species %}
+                      <li>{{ entry.species_name }} <a href="/rna/{{ entry.urs_taxid }}">{{ entry.short_description }}</a></li>
+                    {% endfor %}
+                    </ol>
+                  </div>
+                </div>
+                {% endif %}
+
+                <h2 ng-if="!taxid">Taxonomic tree</h2>
+                <div class="panel panel-default d3-species" ng-if="!taxid">
+                    <div class="tab-pane panel-body d3-species force-scrollbars d3-species-tree-tab">
+                        <taxonomy upi="upi" taxid="taxid"></taxonomy>
+                    </div>
+                </div>
 
                 {% if context.mirna_regulators %}
                   <h2>Targeting miRNAs
@@ -257,9 +281,9 @@ limitations under the License.
 
                 <h2 class="margin-bottom-0px">
                     Sequence
-                    <small>
+                    <!-- <small>
                       <em>{{ rna.upi }}{% if context.taxid %}_{{ context.taxid }}{% endif %}</em>
-                    </small>
+                    </small> -->
                 </h2>
 
                 {% if context.non_canonical_base_counts %}
@@ -293,11 +317,10 @@ limitations under the License.
 
                 <pre ng-if="showSequence" class="pre-scrollable" id="rna-sequence">{{ rna.get_sequence }}</pre>
 
-                <publications upi="upi" taxid="taxid"></publications>
-
+                <publications ng-if="taxid" upi="upi" taxid="taxid"></publications>
             </uib-tab>
 
-            <uib-tab index="1" heading="Taxonomy" deselect="checkTab($event, $selectedIndex)">
+            <uib-tab ng-if="taxid" index="1" heading="Taxonomy" deselect="checkTab($event, $selectedIndex)">
                 <h2>Taxonomic tree</h2>
 
                 <p>

--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -60,7 +60,7 @@ limitations under the License.
             <li ng-if="taxid">
                 Found in <strong>{{ rna.count_distinct_organisms|intcomma }}</strong> <a href="" class="show-species-tab" ng-click="activateTab('1')">species</a>
             </li>
-            <li uib-tooltip="Unique RNA Sequence identifier assigned by RNAcentral">{{rna.upi}}{% if context.taxid %}_{{ context.taxid }}{% endif %}</li>
+            <li uib-tooltip="Unique RNA Sequence identifier assigned by RNAcentral"><abbr>{{rna.upi}}{% if context.taxid %}_{{ context.taxid }}{% endif %}</abbr></li>
             <li class="badge" style="padding-left: 7px; padding-right: 7px;">{{ context.precomputed.rna_type }}</li>
         </ul>
 

--- a/rnacentral/portal/views.py
+++ b/rnacentral/portal/views.py
@@ -138,8 +138,10 @@ def rna_view(request, upi, taxid=None):
         'mirna_regulators': rna.get_mirna_regulators(taxid=taxid),
         'annotations_from_other_species': rna.get_annotations_from_other_species(taxid=taxid),
     }
-
-    return render(request, 'portal/sequence.html', {'rna': rna, 'context': context})
+    if taxid:
+        return render(request, 'portal/sequence.html', {'rna': rna, 'context': context})
+    else:
+        return render(request, 'portal/sequence-no-species.html', {'rna': rna, 'context': context})
 
 
 @cache_page(CACHE_TIMEOUT)


### PR DESCRIPTION
The idea is to clearly differentiate between URS and URS_taxid pages.

**Examples**
- miRNA with 1 species: http://localhost:8000/rna/URS000075A3E5/
- miRNA with 4 species: http://localhost:8000/rna/URS0000759B6D/
- tRNA with 38 species:  http://localhost:8000/rna/URS00001DA281

⚙️🛠 Not ready for merging - I would like to clean up the `sequence.html` template.

Fixes #357 