### PR TITLE
Differentiate URS pages from URS_taxid pages

### DIFF
--- a/rnacentral/portal/models/rna.py
+++ b/rnacentral/portal/models/rna.py
@@ -613,21 +613,20 @@ class Rna(CachingMixin, models.Model):
         return data
 
     def get_annotations_from_other_species(self, taxid=None):
-        if not taxid:
-            return []
         query = '''
-        SELECT t1.id AS urs_taxid, t1.short_description, t2.name as species_name
+        SELECT t1.id AS urs_taxid, t1.short_description, t1.databases, t2.name as species_name
         FROM {rna_precomputed} t1, rnc_taxonomy t2
         WHERE t1.upi = '{urs}'
-        AND t1.taxid != {taxid}
         AND t1.is_active is True
         AND t1.taxid is not NULL
         AND t1.taxid = t2.id
+        {taxid_clause}
         ORDER BY description
         LIMIT 10000
         '''.format(urs=self.upi,
                    taxid=taxid,
-                   rna_precomputed=RnaPrecomputed._meta.db_table
+                   rna_precomputed=RnaPrecomputed._meta.db_table,
+                   taxid_clause='AND t1.taxid != {}'.format(taxid) if taxid else ''
         )
         with connection.cursor() as cursor:
             cursor.execute(query)

--- a/rnacentral/portal/templates/portal/sequence-no-species.html
+++ b/rnacentral/portal/templates/portal/sequence-no-species.html
@@ -1,0 +1,105 @@
+<!--
+Copyright [2009-present] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% extends "portal/base.html" %}
+{% load staticfiles %}
+{% load humanize %}
+
+{% block meta_tags %}
+    {{ block.super }}
+    {% if context.summary_text %}
+    <meta name="description" content="{{ context.precomputed.description }}"/>
+    {% else %}
+    <meta name="description" content="{{ context.precomputed.description }}"/>
+    {% endif %}
+    <meta name="twitter:description" content="{{ context.precomputed.description }}">
+{% endblock %}
+
+{% block title %}
+  {{ rna.upi }}
+{% endblock %}
+
+{% block content %}
+<div class="row" ng-controller="rnaSequenceController">
+    <div ng-if="fetchRnaError" class="col-md-12">
+        <div class="alert alert-danger">
+            <i class="fa fa-exclamation-triangle"></i> Sorry, there was a problem loading sequence from server. Please try again and contact us if the problem persists.
+        </div>
+    </div>
+
+    <div ng-if="rna" class="col-md-12">
+        {% if rna.has_secondary_structure %}
+        <div class="media">
+          <div class="media-left media-middle">
+            <img style="max-width:140px; max-height:120px; margin: 10px;" class="media-object img-thumbnail hvr-grow" src="/api/v1/rna/{{ rna.upi }}/2d/svg/" alt="{{ context.precomputed.description }} secondary structure diagram">
+          </div>
+          <div class="media-body">
+        {% endif %}
+        <h2>
+            {{ context.precomputed.description }}
+            <small>{{ rna.upi }}</small>
+        </h2>
+
+        <ul class="list-inline" id="sequence-overview">
+            <li><strong>{{ rna.length|intcomma }}</strong> nucleotides</li>
+        </ul>
+        {% if rna.has_secondary_structure %}</div><!-- media-body --></div><!-- media -->{% endif %}
+
+        <h2>View detailed species-specific annotations</h2>
+        <p class="small text-muted">
+          This sequence is found in the following species (click to view Rfam classification, secondary structure, and other annotations):
+        </p>
+        <div style="max-height: 400px; overflow:auto;" class="force-scrollbars">
+          <ul>
+          {% for entry in context.annotations_from_other_species %}
+            <li>
+              <a href="/rna/{{ entry.urs_taxid }}">{{ entry.species_name }}</a>
+              <ul class="list-inline small" style="display: inline; margin-left: 5px;">
+                {% for database in entry.databases %}
+                <li>{{ database }}</li>
+                {% endfor %}
+              </ul>
+
+            </li>
+          {% endfor %}
+          </ul>
+        </div>
+
+        <div class="panel panel-default d3-species" style="margin-top:10px;">
+            <div class="tab-pane panel-body d3-species force-scrollbars d3-species-tree-tab">
+                <taxonomy upi="upi" taxid="taxid"></taxonomy>
+            </div>
+        </div>
+
+        <h2>Sequence</h2>
+
+        <div style="padding-top: 10px; padding-bottom: 10px;">
+            <button class="btn btn-default" ng-click="showSequence = !showSequence"><i class="fa fa-align-justify" aria-hidden="true"></i> {% verbatim %}{{ showSequence ? "Hide sequence" : "Show sequence" }}{% endverbatim %}</button>
+            <div ng-if="rna" class="btn-group">
+                <button class="btn btn-default" id="copy-as-rna">
+                  <i class="fa fa-copy" aria-hidden="true"></i> Copy as RNA
+                </button>
+                <button class="btn btn-default" id="copy-as-dna">
+                  <i class="fa fa-copy" aria-hidden="true"></i> Copy as DNA
+                </button>
+            </div>
+            <a class="btn btn-default" href="{% url 'sequence-search' %}?q={{ rna.upi }}" class="margin-left-5px">
+              <i class="fa fa-search" aria-hidden="true"></i> Search for similar sequences
+            </a>
+        </div>
+
+        <pre ng-if="showSequence" class="pre-scrollable" id="rna-sequence">{{ rna.get_sequence }}</pre>
+    </div> <!-- .col-md-12 -->
+</div> <!-- .row -->
+
+{% endblock content %}

--- a/rnacentral/portal/urls.py
+++ b/rnacentral/portal/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     # homepage
     url(r'^$', views.homepage, name='homepage'),
     # unique RNA sequence
-    url(r'^(?i)rna/(?P<upi>URS[0-9A-F]{10})/?$', views.rna_view, name='unique-rna-sequence'),
+    url(r'^(?i)rna/(?P<upi>URS[0-9A-F]{10})/?$', views.rna_urs_view, name='unique-rna-sequence-without-species'),
     # species specific identifier with forward slash
     url(r'^(?i)rna/(?P<upi>URS[0-9A-F]{10})/(?P<taxid>\d+)/?$', views.rna_view, name='unique-rna-sequence'),
     # species specific identifier with underscore


### PR DESCRIPTION
We need to clearly differentiate between URS and URS_taxid pages using the following logic:

- If a URS has only 1 taxid, redirect to a URS_taxid page (this should work for all the URS pages that are already indexed by Google)
- if a URS has multiple taxids, show a page listing the URS_taxid pages:

<img width="1251" alt="Screenshot 2019-12-23 at 09 54 48" src="https://user-images.githubusercontent.com/432675/71350891-44d82b00-256a-11ea-8f17-ef10648e1972.png">

**Examples**

- miRNA with 1 species (redirect): http://localhost:9000/rna/URS000075A3E5/
- SRP with 5 species: http://localhost:9000/rna/URS00000478B7/
- tRNA with 38 species: http://localhost:9000/rna/URS00001DA281

Fixes #357

@blakesweeney @carlosribas - please feel free to give feedback after 🎄 