### PR TITLE
Display Rfam results in sequence search

### DIFF
--- a/rnacentral/portal/static/js/components/routes.service.js
+++ b/rnacentral/portal/static/js/components/routes.service.js
@@ -22,6 +22,8 @@ angular.module("routes", []).service('routes', ['$interpolate', function($interp
         sequenceSearchSubmitJob: '/sequence-search/submit-job',
         sequenceSearchJobStatus: '/sequence-search/job-status/{{ jobId }}',
         sequenceSearchResults: '/sequence-search/job-results/{{ jobId }}',
+        sequenceSearchInfernalJobStatus: '/sequence-search/infernal-job-status/{{ jobId }}',
+        sequenceSearchInfernalResults: '/sequence-search/infernal-results/{{ jobId }}',
         apiEnsemblComparaView: '/api/v1/rna/{{ upi }}/ensembl-compara/{{ taxid }}',
         genomesApi: '/api/v1/genomes/{{ ensemblAssembly }}',
         proxy: '/api/internal/proxy?url={{ url }}',

--- a/rnacentral/portal/static/js/components/sequence-search/sequence-search.module.js
+++ b/rnacentral/portal/static/js/components/sequence-search/sequence-search.module.js
@@ -15,7 +15,8 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
         start: 0,
         size: 20,
         exactMatch: {},
-        textSearchError: false
+        textSearchError: false,
+        infernal: [],
     };
 
     $scope.defaults = {
@@ -31,7 +32,9 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
         submitFailed: 'There was a problem submitting your query. Please try again later or get in touch if the error persists.',
         jobFailed: 'There was a problem with your query. Please try again later or get in touch if the error persists.',
         resultsFailed: 'There was a problem retrieving the results. Please try again later or get in touch if the error persists.',
+        infernalResultsFailed: 'There was a problem retrieving Rfam search results',
         notFoundFailed: 'Job with the specified id was not found.',
+        infernalNotFoundFailed: 'Rfam job was not found.',
         cancelled: 'The search was cancelled',
         pending: 'Pending',
         started: 'Running',
@@ -40,7 +43,7 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
         loadingMoreResults: 'Loading more results',
         tooShort: 'The sequence cannot be shorter than ' + $scope.defaults['minLength'].toString() + ' nucleotides',
         expertDbsError: 'Failed to retrieve the list of expert databases.',
-        textSearchError: 'Failed to retrieve text search facets from EBI search.'
+        textSearchError: 'Failed to retrieve text search facets from EBI search.',
     };
 
     $scope.help = {
@@ -63,13 +66,15 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
 
     $scope.params = {
         searchInProgress: false,
+        infernalSearchDone: false,
         progress: 0,
         errorMessage: '',
         statusMessage: '',
         showAlignments: true,
         showAlignmentStatistics: false,
         selectedOrdering: $scope.ordering[0],
-        textSearchError: false
+        textSearchError: false,
+        help: '/help/sequence-search',
     };
 
     var timeout;
@@ -136,6 +141,32 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
         );
     };
 
+    $scope.fetchInfernalJobResults = function(id) {
+        id = id || $location.search().id;
+
+        $http({
+            url: routes.sequenceSearchInfernalResults({ jobId: id }),
+            method: 'GET',
+        }).then(
+            function(response) {
+                $scope.results.infernal = response.data.sort(function(a, b) {
+                    if ( a.seq_from < b.seq_from ){
+                      return -1;
+                    }
+                    if ( a.seq_from > b.seq_from ){
+                      return 1;
+                    }
+                    return 0;
+                });
+                $scope.params.infernalSearchDone = true;
+            },
+            function(response) {
+                $scope.params.infernalSearchDone = false;
+                $scope.params.errorMessage = $scope.messages.infernalResultsFailed;
+            }
+        );
+    };
+
     /**
      * Check job status using REST API.
      */
@@ -190,7 +221,36 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
                 }
             }
         );
-    }
+
+      };
+
+      function fetchInfernalJobStatus(id) {
+          return $http({
+              url: routes.sequenceSearchInfernalJobStatus({ jobId: id }),
+              method: 'GET',
+              ignoreLoadingBar: true
+          }).then(
+              function(response) {
+                  if (response.data.status === 'success') {
+                      $scope.fetchInfernalJobResults(response.data.id);
+                  }
+                  else {
+                      timeout = setTimeout(function() {
+                          fetchInfernalJobStatus(id);
+                      }, $scope.defaults.pollingInterval);
+                  }
+              },
+              function(response) {
+                  $scope.params.statusMessage = $scope.messages.failed;
+                  if (response.status === 404) {
+                      $scope.params.errorMessage = $scope.messages.infernalNotFoundFailed;
+                  } else {
+                      $scope.params.errorMessage = $scope.messages.infernalResultsFailed;
+                  }
+              }
+          );
+      };
+
 
     /**
      * If sequenceOrUpi is upi, fetch and return the actual sequence from backend.
@@ -227,11 +287,13 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
 
             // begin polling for results
             fetchJobStatus(id);
+            fetchInfernalJobStatus(id);
             updatePageTitle();
         }, function(response) {
             $scope.params.errorMessage = $scope.messages.submitFailed;
             $scope.params.statusMessage = $scope.messages.failed;
             $scope.params.searchInProgress = false;
+            $scope.params.infernalSearchDone = false;
             updatePageTitle();
         });
     }
@@ -354,6 +416,7 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
     $scope.reset = function() {
         $location.search({});
         $scope.params.searchInProgress = false;
+        $scope.params.infernalSearchDone = false;
         $scope.query = {
             sequence: '',
             submitAttempted: false,
@@ -368,7 +431,8 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
             start: 0,
             size: 20,
             exactMatch: {},
-            textSearchError: false
+            textSearchError: false,
+            infernal: [],
         };
         $scope.params.statusMessage = '';
         $scope.params.errorMessage = '';
@@ -566,6 +630,7 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
                 $scope.params.errorMessage = '';
                 $scope.params.statusMessage = $scope.messages.submitting;
                 $scope.params.searchInProgress = true;
+                $scope.params.infernalSearchDone = false;
 
                 // run md5 fetch and actual job submission concurrently
                 fetchExactMatch(sequence);
@@ -666,8 +731,9 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
 
             $scope.results.id = $location.search().id;
 
-            fetchJobStatus($location.search().id).then(function() {
+            fetchJobStatus($scope.results.id).then(function() {
                 fetchExactMatch($scope.query.sequence);
+                fetchInfernalJobStatus($scope.results.id);
             });
         } else if ($location.search().q) {
             // start sequence search

--- a/rnacentral/portal/static/js/components/sequence-search/sequence-search.module.js
+++ b/rnacentral/portal/static/js/components/sequence-search/sequence-search.module.js
@@ -54,14 +54,14 @@ var sequenceSearchController = function($scope, $http, $timeout, $location, $q, 
     };
 
     $scope.ordering = [
-        { sortField: 'e_value', label: 'E-value (low to high)'},
-        { sortField: '-e_value', label: 'E-value (high to low)'},
-        { sortField: '-identity', label: 'Identity ↓' },
-        { sortField: 'identity', label: 'Identity ↑' },
-        { sortField: '-query_coverage', label: 'Query coverage ↓' },
-        { sortField: 'query_coverage', label: 'Query coverage ↑' },
-        { sortField: '-target_coverage', label: 'Target coverage ↓' },
-        { sortField: 'target_coverage', label: 'Target coverage ↑' }
+        { sortField: 'e_value', label: 'Sort by E-value (low to high)'},
+        { sortField: '-e_value', label: 'Sort by E-value (high to low)'},
+        { sortField: '-identity', label: 'Sort by Identity ↓' },
+        { sortField: 'identity', label: 'Sort by Identity ↑' },
+        { sortField: '-query_coverage', label: 'Sort by Query coverage ↓' },
+        { sortField: 'query_coverage', label: 'Sort by Query coverage ↑' },
+        { sortField: '-target_coverage', label: 'Sort by Target coverage ↓' },
+        { sortField: 'target_coverage', label: 'Sort by Target coverage ↑' }
     ];
 
     $scope.params = {

--- a/rnacentral/portal/templates/portal/docs/sequence-search-help.md
+++ b/rnacentral/portal/templates/portal/docs/sequence-search-help.md
@@ -7,6 +7,8 @@ The RNAcentral [sequence similarity search](/sequence-search) enables searches a
 
 The original sequence search was [implemented in 2015](https://blog.rnacentral.org/2015/06/rnacentral-release-3.html) when RNAcentral was much smaller than it is today. As the database grew, some searches were taking too long, so a new sequence search was developed in 2019.
 
+<i class="fa fa-cloud fa-3x pull-left" style="margin-right: 20px;"></i>
+
 The new version runs on a [cloud infrastructure](https://www.embassycloud.org), where each search can be **parallelised** making it much faster. The new user interface allows filtering the results using the same **facets** as the RNAcentral [text search](/help/text-search).
 
 ⚠️ The original sequence search is [still available](/legacy-sequence-search) but will be shut down in early 2020.
@@ -17,7 +19,13 @@ Please be aware that results now show **species-specific identifiers** which inc
 
 ### Exact sequence matches <a style="cursor: pointer" id="exact-matches" ng-click="scrollTo('exact-matches')" name="exact-matches" class="text-muted smaller"><i class="fa fa-link"></i></a>
 
-Whenever a sequence is entered in the search input box, the query is compared with all RNAcentral sequences and if there is an **exact match**, the links to the entries matching the query are displayed in a green box. This is very quick because only identical matches are considered. You can submit the search to see all similar sequences.
+Whenever a sequence is entered in the search input box, the query is compared with all RNAcentral sequences and if there is an **exact match**, the links to the entries matching the query are displayed in a green box. This is very quick because only identical matches are considered. To see all similar sequences, just click Submit.
+
+### Rfam classification <a style="cursor: pointer" id="rfam" ng-click="scrollTo('rfam')" name="rfam" class="text-muted smaller"><i class="fa fa-link"></i></a>
+
+<img src="/static/img/expert-db-logos/rfam.png" class="img-responsive pull-left" style="width: 140px; margin-right: 20px;">
+
+In addition to nhmmer searches against RNAcentral, every query is automatically compared with the [Rfam](https://rfam.org) library of RNA families. The searches are done using the [Infernal](http://eddylab.org/infernal) cmscan program coupled with a [post-processing step](https://github.com/nawrockie/cmsearch_tblout_deoverlap). The post-processing removes any hits that overlap Rfam families from the same clan (a clan is a set of homologous families, for example LSU_rRNA_archaea, LSU_rRNA_bacteria and LSU_rRNA_eukarya). This is a unique functionality not available on the [Rfam website](https://rfam.org) or the [EBI cmscan service](https://www.ebi.ac.uk/Tools/rna/infernal_cmscan/) that report all matching families, including the redundant overlapping hits from the same clan.
 
 ### Searching for ribosomal RNAs <a style="cursor: pointer" id="rrna" ng-click="scrollTo('rrna')" name="rrna" class="text-muted smaller"><i class="fa fa-link"></i></a>
 

--- a/rnacentral/sequence_search/templates/sequence-search.html
+++ b/rnacentral/sequence_search/templates/sequence-search.html
@@ -299,7 +299,7 @@ Sequence search
       </div>
     </div>
 
-    <div class="col-sm-4 col-md-3 hidden-xs text-search-facets" ng-show="params.statusMessage === messages.done && results.hitCount > 0">
+    <div class="col-sm-4 col-md-3 hidden-xs text-search-facets" ng-show="params.statusMessage === messages.done && results.hitCount > 0" style="position: sticky; top: 0;">
       <ul class="list-unstyled">
         <li ng-if="results.textSearchError" class="facet" style="white-space: pre-wrap;">
           <div class="alert alert-warning">{{ messages.textSearchError }}</div>

--- a/rnacentral/sequence_search/templates/sequence-search.html
+++ b/rnacentral/sequence_search/templates/sequence-search.html
@@ -37,23 +37,23 @@ Sequence search
 
   <h1>
     <i class="fa fa-search"></i> Sequence search
-    <small ng-class="(params.searchInProgress && !params.errorMessage) ? '' : 'hidden'">
+    <!-- <small ng-class="(params.searchInProgress && !params.errorMessage) ? '' : 'hidden'">
       <i class="fa fa-spinner fa-spin"></i>
     </small>
     <small id="sequence-search-status">
       {{params.statusMessage}}
-    </small>
+    </small> -->
   </h1>
 
   <div class="well well-sm col-md-10">
     <p>
       Welcome to the new RNAcentral sequence search.
-      Find out <a href={% endverbatim %}"{% url 'help-sequence-search' %}"{% verbatim %}>what's new</a> or
-      go back to the <a href="{% endverbatim %}{% url 'legacy-sequence-search' %}{% verbatim %}">legacy version</a>
+      Find out <a href="{{ params.help }}">what's new</a> or
+      go to the <a href="{% endverbatim %}{% url 'legacy-sequence-search' %}{% verbatim %}">legacy version</a>
     </p>
   </div>
 
-  <span class="col-md-10 small text-muted clearfix">
+  <span class="col-md-10 small text-muted clearfix" style="padding-left: 0;">
     <span>
        Local alignment using <a href="http://www.ncbi.nlm.nih.gov/pubmed/23842809" target="_blank" class="help no-icon" data-toggle="tooltip" title="Wheeler and Eddy, 2013">nhmmer</a>
     </span>
@@ -70,7 +70,7 @@ Sequence search
   <div class="row sequence-search-input">
       <form name="seqQueryForm" novalidate>
 
-        <div class="col-md-10 form-group">
+        <div class="col-md-10 form-group margin-bottom-5px" style="padding-left: 5px;">
           <textarea class="form-control force-scrollbars"
                     rows="6"
                     placeholder="Enter RNA/DNA sequence (with an optional description in FASTA format) or an RNAcentral ID"
@@ -85,7 +85,7 @@ Sequence search
                     required
                     autofocus></textarea>
 
-            <span class="help-block">
+            <span class="help-block margin-bottom-5px">
               Examples:
               <a href="" ng-click="sequenceSearch('>miRNA hsa-let-7a-1 (URS000004F5D8)\nCUAUACAAUCUACUGUCUUUC')">miRNA hsa-let-7a-1</a>
               <span class="small">URS000004F5D8</span>,
@@ -98,7 +98,7 @@ Sequence search
               </em>
             </span>
 
-            <div class="form-group" ng-class="(seqQueryForm.sequence.$invalid) ? 'has-error' : ''">
+            <div class="form-group margin-bottom-0px" ng-class="(seqQueryForm.sequence.$invalid) ? 'has-error' : ''">
               <label class="control-label"
                      for="query-sequence" ng-show="query.submitAttempted && seqQueryForm.sequence.$error.minlength">
                 The sequence cannot be shorter than {{ defaults.minLength }} nucleotides
@@ -133,23 +133,66 @@ Sequence search
       </form><!-- /form -->
   </div><!-- /row -->
 
-  <div class="row">
+  <div class="row" ng-show="results.exactMatch.count > 0"><!-- Pulse animation cannot be on the same element as ng-show -->
     <div class="col-md-10">
-      <div ng-show="results.exactMatch.count > 0"> <!-- Pulse animation cannot be on the same element as ng-show -->
-        <div class="alert alert-success animated pulse margin-bottom-5px" role="alert">
-          Exact match: <a href="/rna/{{ results.exactMatch.rnacentral_id }}" target="_blank">{{results.exactMatch.description}}</a>
-          <span ng-if="results.exactMatch.count > 1">and
-            <a href="/search?q={{ results.exactMatch.urs_id }}*" target="_blank">{{ results.exactMatch.count - 1 | number }} other sequences</a>
-          </span>
-        </div>
+      <div class="alert alert-success animated pulse margin-bottom-5px" role="alert">
+        Exact match: <a href="/rna/{{ results.exactMatch.rnacentral_id }}" target="_blank">{{results.exactMatch.description}}</a>
+        <span ng-if="results.exactMatch.count > 1">and
+          <a href="/search?q={{ results.exactMatch.urs_id }}*" target="_blank">{{ results.exactMatch.count - 1 | number }} other sequences</a>
+        </span>
       </div>
     </div>
   </div>
 
-  <div class="progress" ng-show="params.searchInProgress && params.progress != 100">
+  <div class="row" ng-show="results.infernal.length > 0 && params.infernalSearchDone">
+    <div class="col-md-10 margin-bottom-5px">
+      <h2 class="margin-bottom-0px">
+        Rfam classification
+        <small>
+          <a href="{{ params.help }}" style="color:inherit;" target="_blank">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+          </a>
+        </small>
+      </h2>
+
+      <div class="table-responsive">
+        <table class="table table-hover table-condensed" style="padding-left: 10px; margin-top: 0px;">
+          <thead>
+            <th><abbr class="help" data-placement="top" title="Rfam family">Family</abbr></th>
+            <th><abbr class="help" data-placement="top" title="Rfam accession">Accession</abbr></th>
+            <th><abbr class="help" data-placement="top" title="First nucleotide matching Rfam family">Start</abbr></th>
+            <th><abbr class="help" data-placement="top" title="Last nucleotide matching Rfam family">End</abbr></th>
+            <th><abbr class="help" data-placement="top" title="A measure of similarity between the sequence and the Rfam model (higher is better)">Bit score</abbr></th>
+            <th><abbr class="help" data-placement="top" title="The likelihood of getting this match by chance (lower is better)">E-value</abbr></th>
+            <th><abbr class="help" data-placement="top" title="+ or - depending on whether the sequence matched in forward or reverse orientation">Strand</abbr></th>
+          </thead>
+          <tr ng-repeat="rfam_hit in results.infernal">
+            <td><a href="https://rfam.org/family/{{ rfam_hit.target_name }}" target="_blank" title="View Rfam family" class="no-icon">{{ rfam_hit.description }}</td>
+            <td><a href="https://rfam.org/family/{{ rfam_hit.accession_rfam }}" target="_blank" title="View Rfam family" class="no-icon">{{ rfam_hit.accession_rfam }}</td>
+            <td>{{ rfam_hit.seq_from }}</td>
+            <td>{{ rfam_hit.seq_to }}</td>
+            <td>{{ rfam_hit.score }}</td>
+            <td>{{ rfam_hit.e_value }}</td>
+            <td>{{ rfam_hit.strand }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="row" ng-show="results.infernal.length === 0 && params.infernalSearchDone">
+    <div class="col-md-10">
+      <p style="margin-top: 10px; margin-bottom: 10px; padding-left: 0;">
+        <img src="/static/img/expert-db-logos/rfam.png" class="desaturate" style="width: 80px; vertical-align: bottom; margin-right: 5px;">
+        The query sequence did not match any Rfam families. <a href="{{ params.help }}" target="_blank">Learn more &rarr;</a>
+      </p>
+    </div>
+  </div>
+
+  <div class="progress" ng-show="params.searchInProgress && params.progress != 100 && params.statusMessage !== messages.submitting" style="margin-top: 10px; margin-bottom: 10px;">
     <div class="progress-bar progress-bar-primary active" role="progressbar" aria-valuenow="83"
     aria-valuemin="0" aria-valuemax="100" style="width:{{ params.progress }}%">
-      <span class="margin-left-5px">Searching... {{ params.progress }}%</span>
+      <span class="margin-left-5px">Searching...</span>
     </div>
   </div>
 
@@ -198,85 +241,83 @@ Sequence search
     </div>
   </div>
 
-  <div class="row" ng-show="(params.statusMessage === messages.done && results.hitCount > 0) || query.filter" style="margin-top: 10px;">
-    <div class="col-md-12">
-      <form ng-submit="filterResults()">
-        <div class="form-group">
-          <div class="col-md-4" style="padding-left: 0;">
-            <div class="input-group">
-              <input type="text" class="form-control" ng-model="query.filter" id="queryFilter" placeholder="Filter results">
-              <div class="input-group-btn">
-                <button type="submit" class="btn btn-default help" title="Search within results" data-ng-disabled="!query.filter">
-                  <i style="width: 15px;"></i>
-                  <span><i class="fa fa-filter"></i> Filter</span>
-                </button>
-                <button class="btn btn-default help" data-ng-disabled="!isFilterEnabled()" ng-click="clearFilter()" title="Clear results filtering">
-                  <i style="width: 15px;"></i>
-                  <span><i class="fa fa-ban"></i> Cancel</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-8 margin-bottom-10px" style="padding-left: 0;">
-          <div class="btn-toolbar" role="toolbar">
-            <div class="btn-group" role="group">
-              <a class="btn btn-default help" ng-click="params.showAlignments = !params.showAlignments" title="Alignments between query and hit sequences">
-                <span ng-if="params.showAlignments">Hide</span>
-                <span ng-if="!params.showAlignments">Show</span>
-                alignments
-              </a>
-              <a class="btn btn-default help" ng-click="params.showAlignmentStatistics = !params.showAlignmentStatistics" title="E-value, identity and other information about the hits">
-                <span ng-if="params.showAlignmentStatistics">Hide</span>
-                <span ng-if="!params.showAlignmentStatistics">Show</span>
-                search statistics
-              </a>
-            </div>
-            <div class="btn-group" role="group">
-              <a class="btn btn-default" ng-click="feedback()"><i class="fa fa-comment-o" aria-hidden="true"></i> Send feedback</a>
-            </div>
-            <div class="btn-group" role="group">
-              <a class="btn btn-default help hidden-xs hidden-sm" disabled title="Coming soon"><i class="fa fa-download" aria-hidden="true"></i> Download</a>
-            </div>
-          </div>
-          </div>
-
-        </div>
-      </form>
-    </div>
-  </div>
-
   <div class="row" id="affix-parent">
     <div class="col-md-12">
 
-    <h2 ng-show="results.hitCount > 0">
-      Results
+    <div class="alert col-md-4" ng-if="params.statusMessage === messages.getResuts">
+      <i class="fa fa-2x fa-spinner fa-spin"></i>
+      {{params.statusMessage}}
+    </div>
+
+    <h2 ng-show="params.statusMessage === messages.done && results.hitCount > 0" class="margin-bottom-0px margin-top-5px">
+      Similar sequences
       <small>
         <span ng-if="results.hitCount == 1">1 sequence</span>
-        <span ng-if="results.hitCount > 1">{{ results.entries.length }} out of {{ results.hitCount | number }} sequences</span>
+        <span ng-if="results.hitCount > 1">{{ results.entries.length }} out of {{ results.hitCount | number }}</span>
       </small>
     </h2>
 
-    <div class="col-sm-4 col-md-3 hidden-xs text-search-facets" ng-show="results.hitCount > 0">
-      <ul class="list-unstyled">
-        <li class="facet">
-          <form class="form-inline font-size-14-px hidden-xs " style="padding-left: 0px;">
-            Sort by:
-            <div class="form-group">
-              <select class="form-control small" ng-change="updateOrdering(); fetchJobResults();" ng-model="params.selectedOrdering" ng-options="item.label for item in ordering track by item.label"></select>
+    <div class="row" ng-show="(params.statusMessage === messages.done && results.hitCount > 0) || query.filter" style="margin-bottom: 15px;">
+      <div class="col-md-12">
+        <form ng-submit="filterResults()">
+          <div class="form-group">
+            <div class="col-md-4" style="padding-left: 0;">
+              <div class="input-group">
+                <input type="text" class="form-control" ng-model="query.filter" id="queryFilter" placeholder="Search within results">
+                <div class="input-group-btn">
+                  <button type="submit" class="btn btn-default help" title="Search within results" data-ng-disabled="!query.filter">
+                    <span>Filter</span>
+                  </button>
+                  <button class="btn btn-default help" data-ng-disabled="!isFilterEnabled()" ng-click="clearFilter()" title="Clear results filtering">
+                    <i style="width: 15px;"></i>
+                    <span>Cancel</span>
+                  </button>
+                </div>
+              </div>
             </div>
-          </form>
-        </li>
-        <hr />
+
+            <div class="col-md-8" style="padding-left: 0;">
+              <div class="btn-toolbar" role="toolbar">
+                <div class="btn-group" role="group">
+                  <a class="btn btn-default help" ng-click="params.showAlignments = !params.showAlignments" title="Alignments between query and hit sequences">
+                    <span ng-if="params.showAlignments">Hide</span>
+                    <span ng-if="!params.showAlignments">Show</span>
+                    alignments
+                  </a>
+                  <a class="btn btn-default help" ng-click="params.showAlignmentStatistics = !params.showAlignmentStatistics" title="E-value, identity and other information about the hits">
+                    <span ng-if="params.showAlignmentStatistics">Hide</span>
+                    <span ng-if="!params.showAlignmentStatistics">Show</span>
+                    search statistics
+                  </a>
+                </div>
+                <div class="btn-group" role="group">
+                  <a class="btn btn-default" ng-click="feedback()"><i class="fa fa-comment-o" aria-hidden="true"></i> Send feedback</a>
+                </div>
+                <form class="form-inline font-size-14-px hidden-xs col-md-2">
+                  <span style="margin-left: 5px;">Sort by:<span>
+                  <div class="form-group" style="display: inline-block;">
+                    <select class="form-control small" ng-change="updateOrdering(); fetchJobResults();" ng-model="params.selectedOrdering" ng-options="item.label for item in ordering track by item.label"></select>
+                  </div>
+                </form>
+              </div>
+            </div>
+
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="col-sm-4 col-md-3 hidden-xs text-search-facets" ng-show="params.statusMessage === messages.done && results.hitCount > 0">
+      <ul class="list-unstyled">
         <li ng-if="results.textSearchError" class="facet" style="white-space: pre-wrap;">
           <div class="alert alert-warning">{{ messages.textSearchError }}</div>
         </li>
         <li class="facet scrollable-facet" ng-repeat="facet in results.facets">
           <div ng-if="facet.label === 'Organisms' || facet.label === 'RNA types' || facet.label === 'Expert databases'">
-            <h3>
+            <h3 style="margin-top: 0;">
               {{ facet.label }}
             </h3>
-            <ul class="list-unstyled text-search-facet-values text-search-facet-overflow force-scrollbars" style="overflow-x: hidden;">
+            <ul class="list-unstyled text-search-facet-values text-search-facet-overflow force-scrollbars" style="overflow-x: hidden; margin-bottom: 15px;">
               <li ng-repeat="facetValue in facet.facetValues" ng-if="facet.id == 'expert_db'">
                 <!-- This is expert_dbs facet -->
                 <input type="checkbox" name="facet.label" ng-checked="isFacetApplied(facet.id, facetValue.value)" ng-click="facetToggled(facet.id, facetValue.value)">
@@ -327,7 +368,7 @@ Sequence search
       </small>
     </div>
 
-    <div id="affix-sibling" class="col-xs-12 col-sm-8 col-md-9">
+    <div id="affix-sibling" class="col-xs-12 col-sm-8 col-md-9" ng-show="params.statusMessage === messages.done && results.hitCount > 0">
 
       <ul class="list-unstyled sequence-search-results">
         <li ng-repeat="result in results.entries">
@@ -335,7 +376,7 @@ Sequence search
           <div class="row">
 
           <h4 ng-show="result.rnacentral_id.split('_')[0] === results.exactMatch.urs_id" class="result alert alert-success help" title="Identical to the query (exact match)" style="padding-left: 0; margin-left: 0; margin-top: 0; margin-bottom: 5px;">
-            <a href="/rna/{{result.rnacentral_id}}" target="_blank">{{result.description}}</a>
+            <a href="/rna/{{result.rnacentral_id}}" target="_blank" title="This sequence is identical to the query">{{result.description}}</a>
           </h4>
 
           <h4 ng-show="result.rnacentral_id.split('_')[0] !== results.exactMatch.urs_id" class="result" style="padding-left: 0; margin-left: 0; margin-bottom: 5px; margin-top: 0;">

--- a/rnacentral/sequence_search/templates/sequence-search.html
+++ b/rnacentral/sequence_search/templates/sequence-search.html
@@ -261,47 +261,39 @@ Sequence search
       <div class="col-md-12">
         <form ng-submit="filterResults()">
           <div class="form-group">
-            <div class="col-md-4" style="padding-left: 0;">
-              <div class="input-group">
-                <input type="text" class="form-control" ng-model="query.filter" id="queryFilter" placeholder="Search within results">
-                <div class="input-group-btn">
-                  <button type="submit" class="btn btn-default help" title="Search within results" data-ng-disabled="!query.filter">
-                    <span>Filter</span>
-                  </button>
-                  <button class="btn btn-default help" data-ng-disabled="!isFilterEnabled()" ng-click="clearFilter()" title="Clear results filtering">
-                    <i style="width: 15px;"></i>
-                    <span>Cancel</span>
-                  </button>
-                </div>
+            <div class="input-group col-md-4 col-sm-12" style="float: left;">
+              <input type="text" class="form-control" ng-model="query.filter" id="queryFilter" placeholder="Search within results">
+              <div class="input-group-btn">
+                <button type="submit" class="btn btn-default help" title="Search within results" data-ng-disabled="!query.filter">
+                  <span>Filter</span>
+                </button>
+                <button class="btn btn-default help" data-ng-disabled="!isFilterEnabled()" ng-click="clearFilter()" title="Clear results filtering">
+                  <i style="width: 15px;"></i>
+                  <span>Cancel</span>
+                </button>
               </div>
             </div>
 
-            <div class="col-md-8" style="padding-left: 0;">
-              <div class="btn-toolbar" role="toolbar">
-                <div class="btn-group" role="group">
-                  <a class="btn btn-default help" ng-click="params.showAlignments = !params.showAlignments" title="Alignments between query and hit sequences">
-                    <span ng-if="params.showAlignments">Hide</span>
-                    <span ng-if="!params.showAlignments">Show</span>
-                    alignments
-                  </a>
-                  <a class="btn btn-default help" ng-click="params.showAlignmentStatistics = !params.showAlignmentStatistics" title="E-value, identity and other information about the hits">
-                    <span ng-if="params.showAlignmentStatistics">Hide</span>
-                    <span ng-if="!params.showAlignmentStatistics">Show</span>
-                    search statistics
-                  </a>
-                </div>
-                <div class="btn-group" role="group">
-                  <a class="btn btn-default" ng-click="feedback()"><i class="fa fa-comment-o" aria-hidden="true"></i> Send feedback</a>
-                </div>
-                <form class="form-inline font-size-14-px hidden-xs col-md-2">
-                  <span style="margin-left: 5px;">Sort by:<span>
-                  <div class="form-group" style="display: inline-block;">
-                    <select class="form-control small" ng-change="updateOrdering(); fetchJobResults();" ng-model="params.selectedOrdering" ng-options="item.label for item in ordering track by item.label"></select>
-                  </div>
-                </form>
+            <div class="btn-toolbar col-md-8 col-sm-12" role="toolbar">
+              <div class="btn-group" role="group">
+                <a class="btn btn-default help" ng-click="params.showAlignments = !params.showAlignments" title="Alignments between query and hit sequences">
+                  <span ng-if="params.showAlignments">Hide</span>
+                  <span ng-if="!params.showAlignments">Show</span>
+                  alignments
+                </a>
+                <a class="btn btn-default help" ng-click="params.showAlignmentStatistics = !params.showAlignmentStatistics" title="E-value, identity and other information about the hits">
+                  <span ng-if="params.showAlignmentStatistics">Hide</span>
+                  <span ng-if="!params.showAlignmentStatistics">Show</span>
+                  details
+                </a>
+              </div>
+              <div class="btn-group">
+                <select class="form-control" ng-change="updateOrdering(); fetchJobResults();" ng-model="params.selectedOrdering" ng-options="item.label for item in ordering track by item.label"></select>
+              </div>
+              <div class="btn-group" role="group">
+                <a class="btn btn-default" ng-click="feedback()"><i class="fa fa-comment-o" aria-hidden="true"></i> Feedback</a>
               </div>
             </div>
-
           </div>
         </form>
       </div>

--- a/rnacentral/sequence_search/urls.py
+++ b/rnacentral/sequence_search/urls.py
@@ -35,6 +35,16 @@ urlpatterns = [
         job_results,
         name='sequence-search-job-results'),
 
+    # get job status
+    url(r'^infernal-job-status/(?P<job_id>[A-Za-z0-9_-]+)/?$',
+        infernal_job_status,
+        name='sequence-search-infernal-job-status'),
+
+    # get job results
+    url(r'^infernal-results/(?P<job_id>[A-Za-z0-9_-]+)/?$',
+        infernal_job_results,
+        name='sequence-search-infernal-job-results'),
+
     # show searches
     url(r'^show-searches/?$',
         show_searches,

--- a/rnacentral/sequence_search/views.py
+++ b/rnacentral/sequence_search/views.py
@@ -87,6 +87,23 @@ def job_results(request, job_id):
     url = SEQUENCE_SEARCH_ENDPOINT + '/api/facets-search/' + job_id
     return proxy_request(request, url, 'GET')
 
+@never_cache
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def infernal_job_status(request, job_id):
+    """Displays status of infernal job."""
+    url = SEQUENCE_SEARCH_ENDPOINT + '/api/infernal-status/' + job_id
+    return proxy_request(request, url, 'GET')
+
+
+@never_cache
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def infernal_job_results(request, job_id):
+    """Displays results of a finished infernal job."""
+    url = SEQUENCE_SEARCH_ENDPOINT + '/api/infernal-result/' + job_id
+    return proxy_request(request, url, 'GET')
+
 
 @never_cache
 @api_view(['GET'])


### PR DESCRIPTION
The sequence search UI has been updated to display the Rfam search results - thanks @carlosribas for adding Rfam to the search backend! 

## Examples

[Single Rfam hit](https://test.rnacentral.org/sequence-search/?id=eb93d1d6-a987-47eb-8b1d-7d0f3c64788d&ordering=e_value):
<img width="986" alt="Screenshot 2020-01-03 at 10 32 31" src="https://user-images.githubusercontent.com/432675/71718827-5ba53a00-2e14-11ea-8e5c-64eefa971877.png">

[Several Rfam hits]():
<img width="972" alt="Screenshot 2020-01-03 at 10 29 04" src="https://user-images.githubusercontent.com/432675/71718669-e0438880-2e13-11ea-9c7c-dea2cdcfb5d3.png">

[No Rfam hits](https://test.rnacentral.org/sequence-search/?id=9df599ec-a871-4f18-a774-336b35ebb434&ordering=e_value):
<img width="593" alt="Screenshot 2020-01-03 at 10 30 10" src="https://user-images.githubusercontent.com/432675/71718721-079a5580-2e14-11ea-8ef2-291be32bc075.png">

This section ☝️  looks differently as I don't want to waste space on the `Rfam classification` header.

## Error handling

If there is a problem checking Rfam job status, the following message is shown:

<img width="674" alt="Screenshot 2020-01-03 at 10 37 24" src="https://user-images.githubusercontent.com/432675/71719061-0a497a80-2e15-11ea-9650-3430230c4490.png">

If there is a problem loading the results:

<img width="672" alt="Screenshot 2020-01-03 at 10 37 56" src="https://user-images.githubusercontent.com/432675/71719101-25b48580-2e15-11ea-83d7-5ba0a56b795d.png">

## User-facing documentation

I added a new section about Rfam to the [sequence search docs](https://test.rnacentral.org/help/sequence-search).

## Other changes

I also made a few tweaks to the look and feel of the UI - most notably, the toolbar has been moved just above the facets and the loading indicator is also at the bottom of the page now (where the results will appear) and not at the top.

Any feedback is welcome!
