### PR TITLE
Change rna-2d-species-specific endpoint

### DIFF
--- a/rnacentral/apiv1/urls.py
+++ b/rnacentral/apiv1/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     # view for all cross-references, filtered down to a specific taxon
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/xrefs/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.XrefsSpeciesSpecificList.as_view()), name='rna-xrefs-species-specific'),
     # secondary structure for a species-specific entry
-    url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/2d/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.SecondaryStructureSpeciesSpecificList.as_view()), name='rna-2d-species-specific'),
+    url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/2d(?:/(?P<taxid>\d+))?/$', cache_page(CACHE_TIMEOUT)(views.SecondaryStructureSpeciesSpecificList.as_view()), name='rna-2d-species-specific'),
     # secondary structure thumbnail in SVG format
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/2d/svg/?$', cache_page(CACHE_TIMEOUT)(views.SecondaryStructureSVGImage.as_view()), name='rna-2d-svg'),
     # rfam hits found in this RNAcentral id


### PR DESCRIPTION
Allow access to the endpoint /api/v1/rna/<URS>/2d without specifying a taxid