### PR TITLE
Remove rfam_problems_field

### DIFF
--- a/rnacentral/portal/models/rna_precomputed.py
+++ b/rnacentral/portal/models/rna_precomputed.py
@@ -33,7 +33,6 @@ class RnaPrecomputed(models.Model):
         on_delete=models.CASCADE
     )
     rna_type = models.CharField(max_length=250, null=True)
-    rfam_problems = models.TextField(null=True)
     update_date = models.DateField(null=True)
     has_coordinates = models.BooleanField()
     databases = models.TextField(null=True)


### PR DESCRIPTION
This field is no longer populated by the pipeline or used by the
webcode. It is now repalced by entries in the qa_status table so it
isn't needed. I am removing it as part of a general cleanup of the
precompute table, as it isn't a good idea to keep obsoleted code around.