### PR TITLE
Update qa information

### DIFF
--- a/rnacentral/apiv1/serializers.py
+++ b/rnacentral/apiv1/serializers.py
@@ -21,7 +21,7 @@ from rest_framework import serializers
 
 from portal.models import Rna, Xref,  Reference_map, ChemicalComponent, DatabaseStats, Accession, Reference, \
     Modification, RfamHit, RfamModel, RfamClan, OntologyTerm, SequenceFeature, EnsemblAssembly, EnsemblKaryotype, \
-    ProteinInfo, EnsemblCompara, RnaPrecomputed, SecondaryStructureWithLayout
+    ProteinInfo, EnsemblCompara, RnaPrecomputed, SecondaryStructureWithLayout, QaStatus
 
 
 class RawPublicationSerializer(serializers.ModelSerializer):
@@ -443,17 +443,10 @@ class RfamModelSerializer(serializers.ModelSerializer):
 
 class RfamHitSerializer(serializers.ModelSerializer):
     rfam_model = RfamModelSerializer()
-    rfam_status = serializers.SerializerMethodField()
 
     class Meta:
         model = RfamHit
-        fields = ('sequence_start', 'sequence_stop', 'sequence_completeness', 'rfam_model', 'rfam_status')
-
-    def get_rfam_status(self, obj):
-        if 'taxid' in self.context:
-            return json.loads(obj.upi.get_rfam_status(self.context['taxid']).as_json())
-        else:
-            return json.loads(obj.upi.get_rfam_status().as_json())
+        fields = ('sequence_start', 'sequence_stop', 'sequence_completeness', 'rfam_model')
 
 
 class SequenceFeatureSerializer(serializers.ModelSerializer):
@@ -520,3 +513,9 @@ class RnaPrecomputedJsonSerializer(serializers.ModelSerializer):
 
     def get_databases(self, obj):
         return [database for database in obj.databases.split(',')] if obj.databases else []
+
+
+class QaStatusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = QaStatus
+        fields = '__all__'

--- a/rnacentral/apiv1/urls.py
+++ b/rnacentral/apiv1/urls.py
@@ -54,6 +54,8 @@ urlpatterns = [
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/protein-targets/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.ProteinTargetsView.as_view()), name='rna-protein-targets'),
     # target lncRNA for RNA (species-specific)
     url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/lncrna-targets/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.LncrnaTargetsView.as_view()), name='rna-lncrna-targets'),
+    # Information about the qa status for a given sequence
+    url(r'^rna/(?P<pk>URS[0-9A-Fa-f]{10})/qa-status/(?P<taxid>\d+)/?$', cache_page(CACHE_TIMEOUT)(views.QaStatusView.as_view()), name='qa-status'),
     # literature citations associated with ENA records
     url(r'^accession/(?P<pk>.*?)/citations/?$', cache_page(CACHE_TIMEOUT)(views.CitationsView.as_view()), name='accession-citations'),
     # view for an individual cross-reference

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -37,11 +37,13 @@ from apiv1.serializers import RnaNestedSerializer, AccessionSerializer, Citation
                               RawPublicationSerializer, RnaSecondaryStructureSerializer, \
                               RfamHitSerializer, SequenceFeatureSerializer, \
                               EnsemblAssemblySerializer, ProteinTargetsSerializer, \
-                              LncrnaTargetsSerializer, EnsemblComparaSerializer, SecondaryStructureSVGImageSerializer
+                              LncrnaTargetsSerializer, EnsemblComparaSerializer, SecondaryStructureSVGImageSerializer, \
+                              QaStatusSerializer
 
 from apiv1.renderers import RnaFastaRenderer
 from portal.models import Rna, RnaPrecomputed, Accession, Database, DatabaseStats, RfamHit, EnsemblAssembly,\
-    GoAnnotation, RelatedSequence, ProteinInfo, SequenceFeature, SequenceRegion, EnsemblCompara
+    GoAnnotation, RelatedSequence, ProteinInfo, SequenceFeature, SequenceRegion, EnsemblCompara,\
+    QaStatus
 from portal.config.expert_databases import expert_dbs
 from rnacentral.utils.pagination import Pagination, LargeTablePagination
 
@@ -720,6 +722,16 @@ class LncrnaTargetsView(generics.ListAPIView):
         # queryset = PaginatedRawQuerySet(protein_info_query, model=ProteinInfo)
         queryset = ProteinInfo.objects.raw(protein_info_query)
         return queryset
+
+
+class QaStatusView(APIView):
+    """API endpoint showing the QA status for a sequence"""
+
+    def get(self, _request, pk, taxid):
+        urs_taxid = f'{pk}_{taxid}'
+        status = QaStatus.objects.get(id=urs_taxid)
+        serializer = QaStatusSerializer(status)
+        return Response(serializer.data)
 
 
 class LargerPagination(Pagination):

--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -726,6 +726,8 @@ class LncrnaTargetsView(generics.ListAPIView):
 
 class QaStatusView(APIView):
     """API endpoint showing the QA status for a sequence"""
+    permission_classes = ()
+    authentication_classes = ()
 
     def get(self, _request, pk, taxid):
         urs_taxid = f'{pk}_{taxid}'

--- a/rnacentral/portal/models/__init__.py
+++ b/rnacentral/portal/models/__init__.py
@@ -34,3 +34,4 @@ from .sequence_regions import *
 from .sequence_exons import *
 from .taxonomy import *
 from .ensembl_compara import *
+from .qa_status import *

--- a/rnacentral/portal/models/qa_status.py
+++ b/rnacentral/portal/models/qa_status.py
@@ -1,0 +1,44 @@
+"""
+Copyright [2009-2021] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from django.db import models
+from django.contrib.postgres.fields import JSONField
+
+
+class QaStatus(models.Model):
+    id = models.ForeignKey(
+        'RnaPrecomputed',
+        primary_key=True,
+        db_column='rna_id',
+        to_field='id',
+        related_name='qa_status',
+        on_delete=models.CASCADE,
+    )
+    upi = models.ForeignKey(
+        'Rna',
+        db_column='upi',
+        to_field='upi',
+        related_name='qa_statuses',
+        on_delete=models.CASCADE,
+    )
+    taxid = models.IntegerField()
+    has_issue = models.BooleanField()
+    incomplete_sequence = models.BooleanField()
+    possible_contamination = models.BooleanField()
+    missing_rfam_match = models.BooleanField()
+    from_repetitive_region = models.BooleanField()
+    possible_orf = models.BooleanField()
+    messages = JSONField()
+
+    class Meta:
+        db_table = 'qa_status'

--- a/rnacentral/portal/static/js/components/routes.service.js
+++ b/rnacentral/portal/static/js/components/routes.service.js
@@ -52,6 +52,7 @@ angular.module("routes", []).service('routes', ['$interpolate', function($interp
         apiGoTermsView: '/api/v1/rna/{{ upi }}/go-annotations/{{ taxid }}',
         quickGoSummaryPage: 'https://www.ebi.ac.uk/QuickGO/term/{{ term_id }}',
         quickGoChart: 'https://www.ebi.ac.uk/QuickGO/services/ontology/{{ ontology }}/terms/{{ term_ids }}/chart?base64=true',
+        qaStatusApi: '/api/v1/rna/{{ upi }}/qa-status/{{ taxid }}',
     };
 
 

--- a/rnacentral/portal/static/js/components/sequence/qa-status/qa-status.component.js
+++ b/rnacentral/portal/static/js/components/sequence/qa-status/qa-status.component.js
@@ -1,0 +1,10 @@
+angular.module("rnaSequence").component("qaStatus", {
+    bindings: {
+        qaStatus: '<',
+    },
+    controller: ['$http', '$interpolate', 'routes', function($http, $interpolate, routes) {
+	var ctrl = this;
+    }],
+
+    templateUrl: '/static/js/components/sequence/qa-status/qa-status.html'
+});

--- a/rnacentral/portal/static/js/components/sequence/qa-status/qa-status.html
+++ b/rnacentral/portal/static/js/components/sequence/qa-status/qa-status.html
@@ -1,0 +1,18 @@
+<div>
+  <h2 class="margin-bottom-0px">
+  QA Status
+  </h2>
+
+  <ul ng-if="$ctrl.qaStatus.has_issue" class="list-inline" style="margin-top: 5px; margin-bottom: 1.5em;">
+    <li ng-repeat="problem in $ctrl.qaStatus.messages">
+      <div class="alert alert-warning" style="margin-bottom: 0px">
+        <i class="fa fa-warning fa-2x pull-left text-danger" aria-hidden="true"></i>
+        <span>
+	    <span ng-bind-html="problem"></span>
+        </span>
+      </div>
+    </li>
+  </ul>
+
+  <span><span ng-if="!$ctrl.qaStatus.has_issue">No issues found</span></span>
+</div>

--- a/rnacentral/portal/static/js/components/sequence/rfam/rfam.html
+++ b/rnacentral/portal/static/js/components/sequence/rfam/rfam.html
@@ -16,17 +16,6 @@
     </small>
   </h2>
 
-  <ul ng-if="$ctrl.rfamHits.length > 0 && $ctrl.rfamHits[0].rfam_status.has_issue" class="list-inline" style="margin-top: 5px; margin-bottom: 1.5em;">
-    <li ng-repeat="problem in $ctrl.rfamHits[0].rfam_status.problems">
-      <div class="alert alert-warning" style="margin-bottom: 0px">
-        <i class="fa fa-warning fa-2x pull-left text-danger" aria-hidden="true"></i>
-        <span>
-          <span ng-bind-html="problem.message"></span>
-        </span>
-      </div>
-    </li>
-  </ul>
-
   <ul ng-if="$ctrl.groupedHits.length > 0" class="media-list">
     <li ng-repeat="hit in $ctrl.groupedHits" ng-class="{ 'col-md-10 media': $ctrl.groupedHits.length === 1, 'col-md-6 media': $ctrl.groupedHits.length > 1 }" style="margin-bottom: 1.5em; padding-left: 5px;">
 

--- a/rnacentral/portal/static/js/components/sequence/sequence.module.js
+++ b/rnacentral/portal/static/js/components/sequence/sequence.module.js
@@ -149,6 +149,10 @@ var rnaSequenceController = function($scope, $location, $window, $rootScope, $co
         return $http.get(routes.apiRfamHitsView({upi: $scope.upi, taxid: $scope.taxid}), {params: {page_size: 10000000000}})
     };
 
+    $scope.fetchQaStatus = function() {
+        return $http.get(routes.qaStatusApi({upi: $scope.upi, taxid: $scope.taxid}), {params: {page_size: 10000000000}})
+    };
+
     $scope.fetchSequenceFeatures = function() {
         return $http.get(
             routes.apiSequenceFeaturesView({upi: $scope.upi, taxid: $scope.taxid}),
@@ -609,6 +613,12 @@ var rnaSequenceController = function($scope, $location, $window, $rootScope, $co
                     if (data.length > 0) { addFeature(); }
                 }
             )
+        }
+
+        if ($scope.taxid) {
+          $scope.fetchQaStatus().then(function(response) {
+            $scope.qaStatus = response.data;
+          });
         }
 
         // adjust feature viewer css

--- a/rnacentral/portal/templates/portal/base.html
+++ b/rnacentral/portal/templates/portal/base.html
@@ -227,6 +227,7 @@ limitations under the License.
             <script src="{% static "js/components/sequence/protein-targets/protein-targets.component.js" %}"></script>
             <script src="{% static "js/components/sequence/lncrna-targets/lncrna-targets.component.js" %}"></script>
             <script src="{% static "js/components/sequence/rfam/rfam.component.js" %}"></script>
+            <script src="{% static "js/components/sequence/qa-status/qa-status.component.js" %}"></script>
 
             <script src="{% static "js/components/sequence-search/nhmmer.sequence.search.js" %}"></script>
             <script src="{% static "js/components/sequence-search/sequence-search.module.js" %}"></script>

--- a/rnacentral/portal/templates/portal/sequence.html
+++ b/rnacentral/portal/templates/portal/sequence.html
@@ -337,6 +337,8 @@ limitations under the License.
 
                 </div>
 
+                <qa-status qa-status="qaStatus"></qa-status>
+
                 <rfam ng-if="rfamHits && rna" upi="upi" rna="rna" rfam-hits="rfamHits" rfam-status="rfamStatus" toggle-go-modal="toggleGoModal(term_id)"></rfam>
 
                 <h2 class="margin-bottom-0px">


### PR DESCRIPTION
This adds a new section to the sequence pages to show the QA information. This is done by adding a new API endpoint, `qa-status` and then a new angular component to display the information.

I choose to add a new endpoint because the previous source of this data was from the rfam problems field and this field is flawed. This field doesn't get fetch the qa information or the messages from the database but instead there is an rfam problems module that computes it. I'm unsure if it does the same thing as the pipeline. The new version adds a model for the qa_status table and that is where we now get the messages. A part of the QA pipeline is to compute these messages and add them to the database so I thought we were always using them but weren't. I could also push these messages out to the search index and get them from there but it seemed to be more work. 

This now allows the display of the possible orf messages the pipeline is computing. Also as I add more warnings, say one for pseudogenes or too many mapped locations, the message will show up automatically. That is probably the most useful improvement in this change.

Examples:

You need to run this with prod database and the dev search index. One thing to note is I think the search index is incorrect about which sequences have the orf warning and I'm going to be recompute that shortly. 

- A sequence with an orf warning: http://localhost:8000/rna/URS000017091B/9606
- A sequence with several warnings: http://localhost:8000/rna/URS000049D554/45993
- A sequence without warnings: http://localhost:8000/rna/URS0000A775C3/9606

This could still use some polishing, but feedback now would be great. The things I know I need to improve are:

- Showing a loading spinner while waiting for the response from the API instead of a message that the sequence has no issues
- Fixing the alignment issue for the no issues found message
- Using 'QC' vs 'QA'. We use QC in the search page so I should probably fix the sequence page to say QC too.

One question I'm not sure of yet is if we should delete the old rfam problems field. It may or may not be correct but it is different than the pipeline while removing it would change our API.