### PR TITLE
Improvements to sequence features

### DIFF
--- a/rnacentral/portal/models/sequence_feature.py
+++ b/rnacentral/portal/models/sequence_feature.py
@@ -15,24 +15,31 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 
 
-class SequenceFeature(models.Model):
-    id = models.AutoField(primary_key=True, db_column="rnc_sequence_features_id")
-    accession = models.OneToOneField(
+class SequenceFeatureAccession(models.Model):
+    id = models.AutoField(primary_key=True)
+    rnc_sequence_feature_id = models.IntegerField()
+    accession = models.ForeignField(
         "Accession",
         db_column="accession",
         to_field="accession",
-        related_name="sequence_features",
-        null=True,
         on_delete=models.CASCADE,
     )
+
+    class Meta:
+        db_table = "rnc_accession_sequence_features"
+
+
+class SequenceFeature(models.Model):
+    id = models.AutoField(primary_key=True, db_column="rnc_sequence_feature_id")
+    accession = models.ManyToManyField("Accession", through=SequenceFeatureAccession)
     feature_name = models.CharField(max_length=50)
     metadata = JSONField()
-    start = models.IntegerField()
-    stop = models.IntegerField()
+    start = models.IntegerField(db_column="start_index")
+    stop = models.IntegerField(db_column="stop_index")
     taxid = models.IntegerField()
     upi = models.ForeignKey(
         "RNA",
-        db_column="upi",
+        db_column="urs",
         to_field="upi",
         related_name="sequence_features",
         on_delete=models.CASCADE,


### PR DESCRIPTION
This does several things:

- Move accession column out of rnc_sequence_features, to work better with storing Rfam hits and corrects the representation of the features.
- Rename rnc_sequence_features_id to rnc_sequence_feature_id. That name is weird and reads wrong

- Rename start/stop to start_index/stop_index. I think we should start using something like _index or some other term to indicate that this is a zero based field

- Renames the column upi to urs. We should use this id every where and this is just one step to that.

It's worth discussing if these are good ideas for our database.