### PR TITLE
Improve API documentation

### DIFF
--- a/rnacentral/apiv1/views.py
+++ b/rnacentral/apiv1/views.py
@@ -181,6 +181,29 @@ class GenomeAnnotations(APIView):
 
         return Response(features)
 
+from django.urls import NoReverseMatch
+
+def build_feature_url(request, species, chromosome, start, end):
+    """
+
+    Builds the URL for the feature endpoint based on the provided parameters.
+    This function is a workaround for the reverse() function, which cannot find a compatible regex
+    due to the presence of colons in the pattern.
+
+    Parameters:
+    - request: The Django request object.
+    - species: The species for which the feature URL is being generated.
+    - chromosome: The chromosome number or name for the feature.
+    - start: The start position of the feature.
+    - end: The end position of the feature.
+
+    Returns:
+    - A string representing the absolute URL of the feature endpoint.
+    """
+    base = '/api/v1/feature/region'
+    path = f"{base}/{species}/{chromosome}:{start}-{end}"
+    return request.build_absolute_uri(path)
+
 
 class APIRoot(APIView):
     """
@@ -192,12 +215,45 @@ class APIRoot(APIView):
     # the above docstring appears on the API website
     permission_classes = (AllowAny,)
 
-    def get(self, request, format=format):
-        return Response(
-            {
-                "rna": reverse("rna-sequences", request=request),
-            }
+    def get(self, request, format=None):
+        endpoints = {
+            'rna': 'rna-sequences',
+            'accession': ('accession-detail', {'pk': 'URS000075D2D3'}),
+            'accession_citations': ('accession-citations', {'pk': 'URS000075D2D3'}),
+            #'feature': ('human-genome-coordinates', {'species': 'homo_sapiens', 
+            #                          'chromosome': 'Y', 'start': 1, 'end': 1000000}),
+            # The above does not work because reverse() cannot find a compatible regex
+            # See build_feature_url()
+            
+            'expert-db-stats': 'expert-db-stats',
+            'genomes': 'genomes-api',
+            'genome-browser': ('genome-browser-api', {'species': 'human'}),
+            'litsumm': 'litsumm',
+            'md5': ('md5-sequence', {'md5': '6bba097c8c39ed9a0fdf02273ee1c79a'}),
+        }
+
+        result = {}
+
+        result['feature'] = build_feature_url(
+            request, 
+            species='human',
+            chromosome='Y',
+            start='1',
+            end='1000000'
         )
+
+        for key, value in endpoints.items():
+            # Debuggin implementation to make sure reverse() works
+            try:
+                if isinstance(value, tuple):
+                    result[key] = reverse(value[0], request=request, format=format, kwargs=value[1])
+                else:
+                    result[key] = reverse(value, request=request, format=format)
+            except NoReverseMatch as e:
+                # Skip this endpoint if it can't be reversed
+                pass
+
+        return Response(result)
 
 
 class RnaFilter(filters.FilterSet):

--- a/rnacentral/portal/templates/portal/header.html
+++ b/rnacentral/portal/templates/portal/header.html
@@ -91,6 +91,7 @@ limitations under the License.
           <ul class="dropdown-menu">
             <li><a href="{% url 'api-v1-root' %}">Browsable API</a></li>
             <li><a href="{% url 'api-docs' %}">API Documentation</a></li>
+            <li><a href="{% url 'swagger-ui' %}" target="_blank">OpenAPI Schema</a></li>
           </ul>
         </li>
 

--- a/rnacentral/requirements.txt
+++ b/rnacentral/requirements.txt
@@ -37,3 +37,6 @@ whitenoise==5.2.0
 
 # AWS SDK for Python
 boto3==1.17.54
+
+# drf-spectacular for OpenAPI schema generation
+drf_spectacular

--- a/rnacentral/rnacentral/settings.py
+++ b/rnacentral/rnacentral/settings.py
@@ -252,6 +252,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
     ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [],
     # API results pagination
     "DEFAULT_PAGINATION_CLASS": "rnacentral.utils.pagination.Pagination",
     "PAGE_SIZE": 10,

--- a/rnacentral/rnacentral/settings.py
+++ b/rnacentral/rnacentral/settings.py
@@ -285,6 +285,7 @@ SPECTACULAR_SETTINGS = {
         "rnacentral.utils.drf_spectacular.remove_path",
         "rnacentral.utils.drf_spectacular.fix_path",
     ],
+    "SCHEMA_PATH_PREFIX": r"/api/v[0-9]",
 }
 
 # django-debug-toolbar

--- a/rnacentral/rnacentral/settings.py
+++ b/rnacentral/rnacentral/settings.py
@@ -191,6 +191,7 @@ INSTALLED_APPS = (
     "rest_framework",
     "compressor",
     "markdown_deux",
+    "drf_spectacular",
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
 )
@@ -271,6 +272,14 @@ REST_FRAMEWORK = {
         "rest_framework_yaml.renderers.YAMLRenderer",
         "rest_framework.renderers.BrowsableAPIRenderer",
     ),
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "RNAcentral API",
+    "DESCRIPTION": "RNAcentral API provides programmatic access to RNAcentral data",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
 }
 
 # django-debug-toolbar

--- a/rnacentral/rnacentral/settings.py
+++ b/rnacentral/rnacentral/settings.py
@@ -280,6 +280,10 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "RNAcentral API provides programmatic access to RNAcentral data",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
+    "POSTPROCESSING_HOOKS": [
+        "rnacentral.utils.drf_spectacular.remove_path",
+        "rnacentral.utils.drf_spectacular.fix_path",
+    ],
 }
 
 # django-debug-toolbar

--- a/rnacentral/rnacentral/urls.py
+++ b/rnacentral/rnacentral/urls.py
@@ -15,7 +15,7 @@ import os
 
 from django.conf.urls import include, url
 from django.views.generic import TemplateView
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     # RNAcentral portal
@@ -29,10 +29,12 @@ urlpatterns = [
     url(r"^sequence-search/", include("sequence_search.urls")),
     # Django Debug Toolbar
     # OpenAPI schema
-    url(r'^api/schema/$', SpectacularAPIView.as_view(), name='schema'),
-    # Optional UI:
-    url(r'^api/schema/swagger-ui/$', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-    url(r'^api/schema/redoc/$', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    url(r"^api/schema/$", SpectacularAPIView.as_view(), name="schema"),
+    url(
+        r"^api/schema/swagger-ui/$",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
 ]
 
 # robots.txt extras

--- a/rnacentral/rnacentral/urls.py
+++ b/rnacentral/rnacentral/urls.py
@@ -15,6 +15,7 @@ import os
 
 from django.conf.urls import include, url
 from django.views.generic import TemplateView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
     # RNAcentral portal
@@ -27,6 +28,11 @@ urlpatterns = [
     # new sequence search
     url(r"^sequence-search/", include("sequence_search.urls")),
     # Django Debug Toolbar
+    # OpenAPI schema
+    url(r'^api/schema/$', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    url(r'^api/schema/swagger-ui/$', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    url(r'^api/schema/redoc/$', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 # robots.txt extras

--- a/rnacentral/rnacentral/utils/drf_spectacular.py
+++ b/rnacentral/rnacentral/utils/drf_spectacular.py
@@ -1,0 +1,31 @@
+def remove_path(result, generator, request, public):
+    """
+    Post-processing hook to remove /api/current/ and /sequence-search/ from the schema
+    """
+    paths = result.get("paths", {})
+    excluded_prefixes = ("/api/current/", "/sequence-search/")
+    paths = {
+        key: value
+        for key, value in paths.items()
+        if not key.startswith(excluded_prefixes)
+    }
+    result["paths"] = paths
+    return result
+
+
+def fix_path(result, generator, request, public):
+    """
+    Post-processing hook to normalize paths in the OpenAPI schema:
+    - Fix RNA path patterns containing [_/] to only show /.
+    """
+    paths = result.get("paths", {})
+    updated_paths = {}
+
+    for path, details in paths.items():
+        if "[/_]" in path:
+            path = path.replace("[/_]", "/")
+
+        updated_paths[path] = details
+
+    result["paths"] = updated_paths
+    return result


### PR DESCRIPTION
Hi!

First of all, thank you for putting this incredible resource out there!

I am new to RNAcentral and had some trouble navigating the API to see its capabilities. Since it is implemented using Django REST framework, I was certain that some automatic documentation could be done. So here's what I did:

- Implement [drf_spectacular](https://drf-spectacular.readthedocs.io/en/latest/readme.html), a tool for OpenAPI schema generation.
- Add /schema endpoint to return OpenAPI standard schema, so that it can be used in other applications (for me, it was Postman)
- Include endpoints with UIs to navigate and test the API. These are `/schema/redoc` and `schema/swagger-ui`. For instance, swagger-ui looks like this:
![image](https://github.com/user-attachments/assets/957cd33b-59be-42ff-a89c-cd078e0b936a)

Happy to hear your comments and to edit the `/api` page with the new information if you decide this is worth merging.