### PR TITLE
rna-553 create a team page for RNACentral

### DIFF
--- a/rnacentral/portal/management/commands/create_sitemaps.py
+++ b/rnacentral/portal/management/commands/create_sitemaps.py
@@ -109,12 +109,13 @@ class Command(BaseCommand):
                         "help-secondary-structure",
                         "help-sequence-search",
                         "help-text-search",
+                        "help-team",
                         "help",
                         "homepage",
                         "license",
                         "linking-to-rnacentral",
                         "sequence-search",
-                        "training",
+                        "training"
                     ]
 
                 def location(self, item):

--- a/rnacentral/portal/templates/portal/docs/team.md
+++ b/rnacentral/portal/templates/portal/docs/team.md
@@ -5,11 +5,13 @@
 
 The [RNAcentral](/) database is curated and maintained at the [European Bioinformatics Institute](https://www.ebi.ac.uk/) in Cambridge, UK.
 
-- [Blake Sweeney](https://www.ebi.ac.uk/people/person/blake-sweeney/) Project Leader
-- [Alex Bateman](https://www.ebi.ac.uk/people/person/alex-bateman/) Group Team Leader
-- [Carlos Ribas](https://www.ebi.ac.uk/people/person/carlos-eduardo-ribas/) Full Stack Developer
-- [Philippa Muston](https://www.ebi.ac.uk/people/person/philippa-muston/) Full Stack Developer
+- [Blake Sweeney](https://www.ebi.ac.uk/people/person/blake-sweeney/) - Project Leader
+- [Alex Bateman](https://www.ebi.ac.uk/people/person/alex-bateman/) - Group Team Leader
+- [Carlos Ribas](https://www.ebi.ac.uk/people/person/carlos-eduardo-ribas/) - Full Stack Developer
+- [Philippa Muston](https://www.ebi.ac.uk/people/person/philippa-muston/) - Full Stack Developer
+- [Andrew Green](https://www.ebi.ac.uk/people/person/andrew-green/) - ARISE fellow
 
 ### Previous members
 
-- [John Doe](/) (Harvard University) *SAB member between 2013-2017*
+- Anton Petrov - Project Leader
+- Boris Burkov - Software Developer

--- a/rnacentral/portal/templates/portal/docs/team.md
+++ b/rnacentral/portal/templates/portal/docs/team.md
@@ -1,0 +1,15 @@
+
+# Meet the Team
+
+### Current members
+
+The [RNAcentral](/) database is curated and maintained at the [European Bioinformatics Institute](https://www.ebi.ac.uk/) in Cambridge, UK.
+
+- [Blake Sweeney](https://www.ebi.ac.uk/people/person/blake-sweeney/) Project Leader
+- [Alex Bateman](https://www.ebi.ac.uk/people/person/alex-bateman/) Group Team Leader
+- [Carlos Ribas](https://www.ebi.ac.uk/people/person/carlos-eduardo-ribas/) Full Stack Developer
+- [Philippa Muston](https://www.ebi.ac.uk/people/person/philippa-muston/) Full Stack Developer
+
+### Previous members
+
+- [John Doe](/) (Harvard University) *SAB member between 2013-2017*

--- a/rnacentral/portal/templates/portal/help/sidebar.html
+++ b/rnacentral/portal/templates/portal/help/sidebar.html
@@ -9,6 +9,7 @@
     <li><a href="{% url 'training' %}">Training resources</a></li>
     <li><a href="{% url 'about' %}#growth-chart">Data growth timeline</a></li>
     <li><a href="{% url 'linking-to-rnacentral' %}">Linking to RNAcentral</a></li>
+    <li><a href="{% url 'help-team' %}">Meet the Team</a></li>
     <strong>Data Access</strong>
     <li><a href="{% url 'help-text-search' %}">Text search</a></li>
     <li><a href="{% url 'help-sequence-search' %}">Sequence search</a></li>

--- a/rnacentral/portal/templates/portal/help/team.html
+++ b/rnacentral/portal/templates/portal/help/team.html
@@ -1,0 +1,49 @@
+<!--
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% extends "portal/base.html" %}
+
+{% block meta_tags %}
+    {{ block.super }}
+    <meta name="description" content="Meet the Team"/>
+    <meta name="twitter:description" content="Meet the Team"/>
+{% endblock %}
+
+{% block title %}
+Meet the Team
+{% endblock %}
+
+{% block content %}
+
+<div class="row">
+
+  <div class="col-md-8">
+    {% load markdown_deux_tags %}
+    {% markdown %}
+      {% include  'portal/docs/team.md' %}
+    {% endmarkdown %}
+
+    <hr>
+
+    <a class="btn btn-default btn-sm" title="Edit on GitHub" href="https://github.com/RNAcentral/rnacentral-webcode/edit/master/rnacentral/portal/templates/portal/docs/link-to-rnacentral.md" target="_blank"><i class="fa fa-pencil-square-o"></i> Improve this page</a>
+  </div>
+
+  <div class="col-md-4">
+    {% include 'portal/help/sidebar.html' %}
+  </div>
+
+</div>
+
+<br>
+
+{% endblock %}

--- a/rnacentral/portal/tests/test_views.py
+++ b/rnacentral/portal/tests/test_views.py
@@ -235,6 +235,10 @@ class PortalTest(TestCase):
         response = self.client.get(reverse("help-galaxy"))
         self.assertEqual(response.status_code, 200)
 
+    def test_help_team_status_code(self):
+        response = self.client.get(reverse("help-team"))
+        self.assertEqual(response.status_code, 200)
+
     ########################
     # training, about-us, use-cases, api, contact, thanks, error
     ########################

--- a/rnacentral/portal/urls.py
+++ b/rnacentral/portal/urls.py
@@ -178,6 +178,12 @@ urlpatterns = [
         RedirectView.as_view(url="https://arxiv.org/abs/2311.03056"),
         name="litsumm-manuscript",
     ),
+    re_path(
+        r"^help/team/?$",
+        views.StaticView.as_view(),
+        {"page": "help/team"},
+        name="help-team",
+    ),
     # training
     re_path(
         r"^training/?$",
@@ -236,6 +242,7 @@ urlpatterns = [
     re_path(
         r"^license/?$", views.StaticView.as_view(), {"page": "license"}, name="license"
     ),
+
 ]
 
 # internal API


### PR DESCRIPTION
Ticket: https://linear.app/rna-resources/issue/RNA-553/create-a-team-page-for-rnacentral

The purpose of this PR is to create a Team page for RNACentral in the general help section to list past and present members.