### PR TITLE
Removed check for preexisting static files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,13 +65,10 @@ else
 	chown -R rnacentral "${RNACENTRAL_HOME}"/rnacentral/rnacentral/local_settings.py
 fi
 
-# Run collectstatic only if static files are missing
-if [ -z "$(ls -A /srv/rnacentral/static)" ]; then
-    echo "INFO: Collecting static files..."
-    python "${RNACENTRAL_HOME}"/rnacentral/manage.py collectstatic --noinput
-else
-    echo "INFO: Static files already present, skipping collectstatic."
-fi
+
+echo "INFO: Collecting static files..."
+python "${RNACENTRAL_HOME}"/rnacentral/manage.py collectstatic --noinput
+
 
 # Run django compressor
 echo "INFO: Running django compress"


### PR DESCRIPTION
The purpose of the PR is to solve the static file permission issue encountered when deploying rnacentral pods in prod. Going forward, deploy one replica of the rnacentral with the following commands:

helm install full-prod . --set rnacentralReplicas=1
helm upgrade --install full-prod . --set rnacentralReplicas=1

 then scale up to eight:

kubectl scale deployment --replicas=7 rnacentral